### PR TITLE
Add Verity design document and phased implementation plans

### DIFF
--- a/docs/plans/2026-03-11-phase-0-gradle-scaffolding.md
+++ b/docs/plans/2026-03-11-phase-0-gradle-scaffolding.md
@@ -1,0 +1,476 @@
+# Phase 0: Gradle Scaffolding — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Set up the Gradle multi-module project structure for Verity with all dependency declarations.
+
+**Architecture:** A root Gradle project containing a `verity/` parent module with five submodules (core, device, agent, mcp, cli). Version catalog in `gradle/libs.versions.toml` centralizes all dependency versions. Each module declares only its own dependencies.
+
+**Tech Stack:** Gradle 8.x, Kotlin 2.1.20, kotlinx.serialization 1.8.0
+
+**Design doc:** `docs/plans/2026-03-11-verity-design.md`
+
+---
+
+### Task 1: Create version catalog
+
+**Files:**
+- Create: `gradle/libs.versions.toml`
+
+**Step 1: Verify latest stable dependency versions first**
+
+Before writing `libs.versions.toml`, verify the latest stable versions for **all** entries (`kotlin`, coroutines, serialization, Ktor, Koog, Maestro, MCP SDK, gRPC, etc.) using source registries (Maven Central / Gradle Plugin Portal / project release pages).
+
+Do not copy stale versions blindly from this plan. Treat the block below as a structure/template and refresh versions at implementation time.
+
+**Step 2: Create the version catalog file**
+
+```toml
+[versions]
+kotlin = "2.1.20"
+kotlinx-serialization = "1.8.0"
+kotlinx-coroutines = "1.10.1"
+kaml = "0.67.0"
+koog = "0.6.4"
+clikt = "5.1.0"
+ktor = "3.1.1"
+maestro-client = "2.0.10"
+maestro-ios = "2.2.0"
+dadb = "1.2.7"
+mcp-kotlin = "0.8.3"
+grpc = "1.57.2"
+grpc-kotlin = "1.4.1"
+grpc-netty-shaded = "1.57.2"
+assertk = "0.28.1"
+
+[libraries]
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
+koog-agents = { module = "ai.koog:koog-agents", version.ref = "koog" }
+koog-anthropic = { module = "ai.koog:prompt-executor-anthropic-client", version.ref = "koog" }
+clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
+ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+maestro-client = { module = "dev.mobile:maestro-client", version.ref = "maestro-client" }
+maestro-ios-driver = { module = "dev.mobile:maestro-ios-driver", version.ref = "maestro-ios" }
+dadb = { module = "dev.mobile:dadb", version.ref = "dadb" }
+mcp-kotlin-sdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcp-kotlin" }
+grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc-netty-shaded" }
+grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
+grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc" }
+grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpc-kotlin" }
+assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+```
+
+**Step 3: Commit**
+
+```bash
+git add gradle/libs.versions.toml
+git commit -m "feat: add Gradle version catalog with all dependency versions"
+```
+
+---
+
+### Task 2: Create root build and settings files
+
+**Files:**
+- Create: `settings.gradle.kts`
+- Create: `build.gradle.kts`
+
+**Step 1: Create settings.gradle.kts**
+
+```kotlin
+rootProject.name = "verity"
+
+include(":verity:core")
+include(":verity:device")
+include(":verity:agent")
+include(":verity:mcp")
+include(":verity:cli")
+```
+
+**Step 2: Create root build.gradle.kts**
+
+```kotlin
+plugins {
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add settings.gradle.kts build.gradle.kts
+git commit -m "feat: add root settings and build files with module includes"
+```
+
+---
+
+### Task 3: Create verity parent build file
+
+**Files:**
+- Create: `verity/build.gradle.kts`
+
+**Step 1: Create the shared build config**
+
+```kotlin
+subprojects {
+    apply(plugin = "org.jetbrains.kotlin.jvm")
+
+    group = "me.chrisbanes.verity"
+    version = "0.1.0"
+
+    repositories {
+        mavenCentral()
+    }
+
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
+
+    dependencies {
+        "testImplementation"(kotlin("test"))
+        "testImplementation"(rootProject.libs.assertk)
+        "testImplementation"(rootProject.libs.kotlinx.coroutines.test)
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/build.gradle.kts
+git commit -m "feat: add shared verity parent build config"
+```
+
+---
+
+### Task 4: Create core module build file
+
+**Files:**
+- Create: `verity/core/build.gradle.kts`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/.gitkeep`
+- Create: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/.gitkeep`
+
+**Step 1: Create core build.gradle.kts**
+
+`:verity:core` has zero SDK dependencies — only kotlinx.serialization and Kaml.
+
+```kotlin
+plugins {
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kaml)
+    implementation(libs.kotlinx.coroutines.core)
+}
+```
+
+**Step 2: Create placeholder source directories**
+
+```bash
+mkdir -p verity/core/src/main/kotlin/me/chrisbanes/verity/core
+mkdir -p verity/core/src/test/kotlin/me/chrisbanes/verity/core
+touch verity/core/src/main/kotlin/me/chrisbanes/verity/core/.gitkeep
+touch verity/core/src/test/kotlin/me/chrisbanes/verity/core/.gitkeep
+```
+
+**Step 3: Commit**
+
+```bash
+git add verity/core/
+git commit -m "feat: add :verity:core module with serialization dependencies"
+```
+
+---
+
+### Task 5: Create device module build file
+
+**Files:**
+- Create: `verity/device/build.gradle.kts`
+- Create: `verity/device/src/main/kotlin/me/chrisbanes/verity/device/.gitkeep`
+- Create: `verity/device/src/test/kotlin/me/chrisbanes/verity/device/.gitkeep`
+
+**Step 1: Create device build.gradle.kts**
+
+`:verity:device` depends on core and the Maestro/Dadb SDKs. This is where the Netty conflict resolution lives.
+
+```kotlin
+dependencies {
+    implementation(project(":verity:core"))
+    implementation(libs.kotlinx.coroutines.core)
+
+    // Android device
+    implementation(libs.dadb)
+    implementation(libs.maestro.client) {
+        exclude(group = "io.grpc", module = "grpc-netty")
+    }
+
+    // iOS device
+    implementation(libs.maestro.ios.driver)
+
+    // gRPC with shaded Netty to avoid Ktor conflict
+    implementation(libs.grpc.netty.shaded)
+    implementation(libs.grpc.stub)
+    implementation(libs.grpc.protobuf)
+}
+
+configurations.all {
+    resolutionStrategy {
+        force("io.grpc:grpc-stub:${libs.versions.grpc.get()}")
+        force("io.grpc:grpc-protobuf:${libs.versions.grpc.get()}")
+        force("io.grpc:grpc-core:${libs.versions.grpc.get()}")
+        force("io.grpc:grpc-api:${libs.versions.grpc.get()}")
+        force("io.grpc:grpc-context:${libs.versions.grpc.get()}")
+    }
+}
+```
+
+**Step 2: Create placeholder source directories**
+
+```bash
+mkdir -p verity/device/src/main/kotlin/me/chrisbanes/verity/device
+mkdir -p verity/device/src/test/kotlin/me/chrisbanes/verity/device
+touch verity/device/src/main/kotlin/me/chrisbanes/verity/device/.gitkeep
+touch verity/device/src/test/kotlin/me/chrisbanes/verity/device/.gitkeep
+```
+
+**Step 3: Commit**
+
+```bash
+git add verity/device/
+git commit -m "feat: add :verity:device module with Maestro SDK and Dadb dependencies"
+```
+
+---
+
+### Task 6: Create agent module build file
+
+**Files:**
+- Create: `verity/agent/build.gradle.kts`
+- Create: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/.gitkeep`
+- Create: `verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/.gitkeep`
+
+**Step 1: Create agent build.gradle.kts**
+
+`:verity:agent` depends on core, device, and Koog.
+
+```kotlin
+dependencies {
+    implementation(project(":verity:core"))
+    implementation(project(":verity:device"))
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.koog.agents)
+    implementation(libs.koog.anthropic)
+}
+```
+
+**Step 2: Create placeholder source directories**
+
+```bash
+mkdir -p verity/agent/src/main/kotlin/me/chrisbanes/verity/agent
+mkdir -p verity/agent/src/test/kotlin/me/chrisbanes/verity/agent
+touch verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/.gitkeep
+touch verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/.gitkeep
+```
+
+**Step 3: Commit**
+
+```bash
+git add verity/agent/
+git commit -m "feat: add :verity:agent module with Koog LLM dependencies"
+```
+
+---
+
+### Task 7: Create MCP module build file
+
+**Files:**
+- Create: `verity/mcp/build.gradle.kts`
+- Create: `verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/.gitkeep`
+- Create: `verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/.gitkeep`
+
+**Step 1: Create mcp build.gradle.kts**
+
+`:verity:mcp` depends on core, device, MCP SDK, and Ktor. Does NOT depend on agent.
+
+```kotlin
+dependencies {
+    implementation(project(":verity:core"))
+    implementation(project(":verity:device"))
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.mcp.kotlin.sdk)
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+}
+```
+
+**Step 2: Create placeholder source directories**
+
+```bash
+mkdir -p verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp
+mkdir -p verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp
+touch verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/.gitkeep
+touch verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/.gitkeep
+```
+
+**Step 3: Commit**
+
+```bash
+git add verity/mcp/
+git commit -m "feat: add :verity:mcp module with MCP SDK and Ktor dependencies"
+```
+
+---
+
+### Task 8: Create CLI module build file
+
+**Files:**
+- Create: `verity/cli/build.gradle.kts`
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/.gitkeep`
+- Create: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/.gitkeep`
+
+**Step 1: Create cli build.gradle.kts**
+
+`:verity:cli` depends on agent and mcp. This is the application entry point.
+
+```kotlin
+plugins {
+    application
+}
+
+application {
+    mainClass.set("me.chrisbanes.verity.cli.VerityKt")
+}
+
+dependencies {
+    implementation(project(":verity:agent"))
+    implementation(project(":verity:mcp"))
+    implementation(libs.clikt)
+}
+```
+
+**Step 2: Create placeholder source directories**
+
+```bash
+mkdir -p verity/cli/src/main/kotlin/me/chrisbanes/verity/cli
+mkdir -p verity/cli/src/test/kotlin/me/chrisbanes/verity/cli
+touch verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/.gitkeep
+touch verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/.gitkeep
+```
+
+**Step 3: Commit**
+
+```bash
+git add verity/cli/
+git commit -m "feat: add :verity:cli module with Clikt dependency"
+```
+
+---
+
+### Task 9: Add Gradle wrapper and verify compilation
+
+**Step 1: Ensure Gradle wrapper is present**
+
+If not already present, generate it:
+
+```bash
+gradle wrapper --gradle-version 8.12
+```
+
+**Step 2: Verify the project compiles**
+
+```bash
+./gradlew :verity:core:compileKotlin :verity:device:compileKotlin :verity:agent:compileKotlin :verity:mcp:compileKotlin :verity:cli:compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL (no source files yet, but dependency resolution and configuration should succeed).
+
+**Step 3: Commit wrapper if generated**
+
+```bash
+git add gradlew gradlew.bat gradle/
+git commit -m "feat: add Gradle wrapper"
+```
+
+---
+
+### Task 10: Create skills directory structure
+
+**Files:**
+- Create: `verity/skills/context/procedures.md` (empty placeholder)
+- Create: `verity/skills/run/SKILL.md` (empty placeholder)
+- Create: `verity/skills/author/SKILL.md` (empty placeholder)
+
+Skills are not a Gradle module — just markdown files.
+
+**Step 1: Create directory structure with placeholders**
+
+```bash
+mkdir -p verity/skills/context verity/skills/run verity/skills/author
+echo "# Shared Procedures" > verity/skills/context/procedures.md
+echo "# Verity Run Skill" > verity/skills/run/SKILL.md
+echo "# Verity Author Skill" > verity/skills/author/SKILL.md
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/skills/
+git commit -m "feat: add skills directory structure with placeholders"
+```
+
+---
+
+## Verification
+
+After all tasks complete, the project structure should be:
+
+```
+verity/
+├── build.gradle.kts                     # Root
+├── settings.gradle.kts                  # Module includes
+├── gradle/
+│   └── libs.versions.toml              # Version catalog
+├── gradlew
+├── gradlew.bat
+└── verity/
+    ├── build.gradle.kts                 # Shared subproject config
+    ├── core/
+    │   ├── build.gradle.kts
+    │   └── src/{main,test}/kotlin/me/chrisbanes/verity/core/
+    ├── device/
+    │   ├── build.gradle.kts
+    │   └── src/{main,test}/kotlin/me/chrisbanes/verity/device/
+    ├── agent/
+    │   ├── build.gradle.kts
+    │   └── src/{main,test}/kotlin/me/chrisbanes/verity/agent/
+    ├── mcp/
+    │   ├── build.gradle.kts
+    │   └── src/{main,test}/kotlin/me/chrisbanes/verity/mcp/
+    ├── cli/
+    │   ├── build.gradle.kts
+    │   └── src/{main,test}/kotlin/me/chrisbanes/verity/cli/
+    └── skills/
+        ├── context/procedures.md
+        ├── run/SKILL.md
+        └── author/SKILL.md
+```
+
+Run `./gradlew projects` to confirm all modules are recognized.

--- a/docs/plans/2026-03-11-phase-1-core.md
+++ b/docs/plans/2026-03-11-phase-1-core.md
@@ -1,0 +1,2211 @@
+# Phase 1: `:verity:core` — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the core module containing all data models, journey parsing, segmentation, key mapping, hierarchy rendering, and context loading — with zero device or LLM SDK dependencies.
+
+**Architecture:** Pure Kotlin data types and parsing logic. The `[?]` assertion syntax is parsed by a custom Kaml serializer. Step inference uses a priority chain: explicit prefix, generic assert, loop inference, NL assertion inference, default action. Everything is unit-testable without device connections or API keys.
+
+**Tech Stack:** Kotlin, kotlinx.serialization, Kaml, kotlinx.coroutines
+
+**Design doc:** `docs/plans/2026-03-11-verity-design.md`
+
+**Prerequisite:** Phase 0 (Gradle scaffolding) complete.
+
+---
+
+### Task 1: Core enums — Platform and AssertMode
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/model/Platform.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/model/AssertMode.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/model/AssertModeTest.kt`
+
+**Step 1: Write the test**
+
+```kotlin
+package me.chrisbanes.verity.core.model
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.containsExactly
+import kotlin.test.Test
+
+class AssertModeTest {
+    @Test
+    fun `assert modes are ordered by cost`() {
+        val modes = AssertMode.entries.sortedBy { it.ordinal }
+        assertThat(modes).containsExactly(
+            AssertMode.VISIBLE,
+            AssertMode.FOCUSED,
+            AssertMode.TREE,
+            AssertMode.VISUAL,
+        )
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.model.AssertModeTest"`
+Expected: FAIL — class not found
+
+**Step 3: Write the enums**
+
+`Platform.kt`:
+```kotlin
+package me.chrisbanes.verity.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class Platform {
+    @SerialName("android-tv") ANDROID_TV,
+    @SerialName("android") ANDROID_MOBILE,
+    @SerialName("ios") IOS,
+}
+```
+
+`AssertMode.kt`:
+```kotlin
+package me.chrisbanes.verity.core.model
+
+// Ordered by cost: VISIBLE and FOCUSED are free (deterministic),
+// TREE uses text LLM, VISUAL uses vision LLM.
+enum class AssertMode {
+    VISIBLE,
+    FOCUSED,
+    TREE,
+    VISUAL,
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.model.AssertModeTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add Platform and AssertMode enums"
+```
+
+---
+
+### Task 2: JourneyStep sealed interface
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/model/JourneyStep.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/model/JourneyStepTest.kt`
+
+**Step 1: Write the test**
+
+```kotlin
+package me.chrisbanes.verity.core.model
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import kotlin.test.Test
+
+class JourneyStepTest {
+    @Test
+    fun `action step holds instruction`() {
+        val step: JourneyStep = JourneyStep.Action("Press D-pad down")
+        assertThat(step).isInstanceOf<JourneyStep.Action>()
+        assertThat((step as JourneyStep.Action).instruction).isEqualTo("Press D-pad down")
+    }
+
+    @Test
+    fun `assert step holds description and mode`() {
+        val step = JourneyStep.Assert("Home", AssertMode.VISIBLE)
+        assertThat(step.description).isEqualTo("Home")
+        assertThat(step.mode).isEqualTo(AssertMode.VISIBLE)
+    }
+
+    @Test
+    fun `loop step has default max of 20`() {
+        val step = JourneyStep.Loop(action = "Press D-pad down", until = "TV Shows")
+        assertThat(step.max).isEqualTo(20)
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.model.JourneyStepTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.core.model
+
+sealed interface JourneyStep {
+    data class Action(val instruction: String) : JourneyStep
+    data class Assert(val description: String, val mode: AssertMode) : JourneyStep
+    data class Loop(val action: String, val until: String, val max: Int = 20) : JourneyStep
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.model.JourneyStepTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add JourneyStep sealed interface"
+```
+
+---
+
+### Task 3: Journey and JourneySegment data classes
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/model/Journey.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/model/JourneySegment.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/model/JourneySegmentTest.kt`
+
+**Step 1: Write the test**
+
+```kotlin
+package me.chrisbanes.verity.core.model
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import kotlin.test.Test
+
+class JourneySegmentTest {
+    @Test
+    fun `segment with actions and assertion`() {
+        val segment = JourneySegment(
+            index = 0,
+            actions = listOf(JourneyStep.Action("Launch the app")),
+            assertion = JourneyStep.Assert("Home", AssertMode.VISIBLE),
+        )
+        assertThat(segment.actions.size).isEqualTo(1)
+        assertThat(segment.assertion?.description).isEqualTo("Home")
+        assertThat(segment.loop).isNull()
+    }
+
+    @Test
+    fun `segment with loop and no assertion`() {
+        val segment = JourneySegment(
+            index = 1,
+            actions = emptyList(),
+            loop = JourneyStep.Loop("Press D-pad down", "TV Shows"),
+        )
+        assertThat(segment.assertion).isNull()
+        assertThat(segment.loop?.until).isEqualTo("TV Shows")
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.model.JourneySegmentTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+`Journey.kt`:
+```kotlin
+package me.chrisbanes.verity.core.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Journey(
+    val name: String,
+    val app: String,
+    val platform: Platform,
+    val steps: List<JourneyStep>,
+)
+```
+
+Note: `Journey` uses `@Serializable` but `JourneyStep` will need a custom serializer (Task 7). For now the annotation on `Journey` won't compile until the serializer is added. Mark `steps` with `@Contextual` temporarily, or defer the `@Serializable` annotation until Task 7. Simplest approach: **do not annotate Journey with @Serializable yet** — just make it a plain data class for now. The Kaml deserialization will be wired in Task 7.
+
+```kotlin
+package me.chrisbanes.verity.core.model
+
+data class Journey(
+    val name: String,
+    val app: String,
+    val platform: Platform,
+    val steps: List<JourneyStep>,
+)
+```
+
+`JourneySegment.kt`:
+```kotlin
+package me.chrisbanes.verity.core.model
+
+data class JourneySegment(
+    val index: Int,
+    val actions: List<JourneyStep.Action>,
+    val assertion: JourneyStep.Assert? = null,
+    val loop: JourneyStep.Loop? = null,
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.model.JourneySegmentTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add Journey and JourneySegment data classes"
+```
+
+---
+
+### Task 4: Result types — FlowResult and InspectionVerdict
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/model/FlowResult.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/model/InspectionVerdict.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/model/ResultTypesTest.kt`
+
+**Step 1: Write the test**
+
+```kotlin
+package me.chrisbanes.verity.core.model
+
+import assertk.assertThat
+import assertk.assertions.isTrue
+import assertk.assertions.isFalse
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class ResultTypesTest {
+    @Test
+    fun `flow result success`() {
+        val result = FlowResult(success = true, output = "Flow completed")
+        assertThat(result.success).isTrue()
+    }
+
+    @Test
+    fun `flow result failure`() {
+        val result = FlowResult(success = false, output = "Element not found")
+        assertThat(result.success).isFalse()
+    }
+
+    @Test
+    fun `inspection verdict passed`() {
+        val verdict = InspectionVerdict(passed = true, reasoning = "Home text found in hierarchy")
+        assertThat(verdict.passed).isTrue()
+        assertThat(verdict.reasoning).isEqualTo("Home text found in hierarchy")
+    }
+
+    @Test
+    fun `inspection verdict failed`() {
+        val verdict = InspectionVerdict(passed = false, reasoning = "Expected 'Movies' but not found")
+        assertThat(verdict.passed).isFalse()
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.model.ResultTypesTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+`FlowResult.kt`:
+```kotlin
+package me.chrisbanes.verity.core.model
+
+data class FlowResult(
+    val success: Boolean,
+    val output: String = "",
+)
+```
+
+`InspectionVerdict.kt`:
+```kotlin
+package me.chrisbanes.verity.core.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class InspectionVerdict(
+    val passed: Boolean,
+    val reasoning: String,
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.model.ResultTypesTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add FlowResult and InspectionVerdict result types"
+```
+
+---
+
+### Task 5: AssertModeInferrer
+
+The inferrer selects the cheapest assertion mode from a description string:
+- Visual keywords → VISUAL
+- 3 words or fewer, no visual keywords → VISIBLE
+- Everything else → TREE
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/parser/AssertModeInferrer.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/parser/AssertModeInferrerTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.parser
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import me.chrisbanes.verity.core.model.AssertMode
+import kotlin.test.Test
+
+class AssertModeInferrerTest {
+    @Test
+    fun `short text without visual keywords infers VISIBLE`() {
+        assertThat(AssertModeInferrer.infer("Home")).isEqualTo(AssertMode.VISIBLE)
+    }
+
+    @Test
+    fun `three words without visual keywords infers VISIBLE`() {
+        assertThat(AssertModeInferrer.infer("TV Shows row")).isEqualTo(AssertMode.VISIBLE)
+    }
+
+    @Test
+    fun `four words without visual keywords infers TREE`() {
+        assertThat(AssertModeInferrer.infer("Detail page shows title")).isEqualTo(AssertMode.TREE)
+    }
+
+    @Test
+    fun `text with image keyword infers VISUAL`() {
+        assertThat(AssertModeInferrer.infer("Backdrop image is visible")).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `text with color keyword infers VISUAL`() {
+        assertThat(AssertModeInferrer.infer("Button color is red")).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `text with icon keyword infers VISUAL`() {
+        assertThat(AssertModeInferrer.infer("Play icon is displayed")).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `text with highlight keyword infers VISUAL`() {
+        assertThat(AssertModeInferrer.infer("Selected item has highlight")).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `text with animation keyword infers VISUAL`() {
+        assertThat(AssertModeInferrer.infer("Loading animation plays")).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `text with gradient keyword infers VISUAL`() {
+        assertThat(AssertModeInferrer.infer("Background has gradient")).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `text with blur keyword infers VISUAL`() {
+        assertThat(AssertModeInferrer.infer("Background blur effect")).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `visual keyword matching is case insensitive`() {
+        assertThat(AssertModeInferrer.infer("BACKDROP IMAGE visible")).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `longer text without visual keywords infers TREE`() {
+        assertThat(AssertModeInferrer.infer("Synopsis contains at least 2 sentences"))
+            .isEqualTo(AssertMode.TREE)
+    }
+
+    @Test
+    fun `single word infers VISIBLE`() {
+        assertThat(AssertModeInferrer.infer("Settings")).isEqualTo(AssertMode.VISIBLE)
+    }
+
+    @Test
+    fun `empty string infers VISIBLE`() {
+        assertThat(AssertModeInferrer.infer("")).isEqualTo(AssertMode.VISIBLE)
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.parser.AssertModeInferrerTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.core.parser
+
+import me.chrisbanes.verity.core.model.AssertMode
+
+object AssertModeInferrer {
+
+    private val VISUAL_KEYWORDS = setOf(
+        "color", "colour", "highlight", "image", "icon", "animation",
+        "gradient", "blur", "backdrop", "thumbnail", "poster", "artwork",
+        "badge", "logo", "overlay", "opacity", "shadow", "border",
+    )
+
+    fun infer(description: String): AssertMode {
+        val lower = description.lowercase()
+        val words = lower.split("\\s+".toRegex()).filter { it.isNotEmpty() }
+
+        if (words.any { it in VISUAL_KEYWORDS }) return AssertMode.VISUAL
+        if (words.size <= 3) return AssertMode.VISIBLE
+        return AssertMode.TREE
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.parser.AssertModeInferrerTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add AssertModeInferrer with cost-aware heuristics"
+```
+
+---
+
+### Task 6: LoopStepInferrer
+
+Detects loop patterns in natural language: `<verb> ... until <condition> [up to N times]`.
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/parser/LoopStepInferrer.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/parser/LoopStepInferrerTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.parser
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import me.chrisbanes.verity.core.model.JourneyStep
+import kotlin.test.Test
+
+class LoopStepInferrerTest {
+    @Test
+    fun `simple until pattern`() {
+        val result = LoopStepInferrer.infer("Navigate down until TV Shows row")
+        assertThat(result).isNotNull()
+        assertThat(result!!.action).isEqualTo("Navigate down")
+        assertThat(result.until).isEqualTo("TV Shows row")
+        assertThat(result.max).isEqualTo(20)
+    }
+
+    @Test
+    fun `press until pattern`() {
+        val result = LoopStepInferrer.infer("Press D-pad down until Settings")
+        assertThat(result).isNotNull()
+        assertThat(result!!.action).isEqualTo("Press D-pad down")
+        assertThat(result.until).isEqualTo("Settings")
+    }
+
+    @Test
+    fun `scroll until pattern`() {
+        val result = LoopStepInferrer.infer("Scroll down until end of list")
+        assertThat(result).isNotNull()
+        assertThat(result!!.action).isEqualTo("Scroll down")
+        assertThat(result.until).isEqualTo("end of list")
+    }
+
+    @Test
+    fun `with max iterations`() {
+        val result = LoopStepInferrer.infer("Navigate down until TV Shows up to 10 times")
+        assertThat(result).isNotNull()
+        assertThat(result!!.action).isEqualTo("Navigate down")
+        assertThat(result.until).isEqualTo("TV Shows")
+        assertThat(result.max).isEqualTo(10)
+    }
+
+    @Test
+    fun `non-loop action returns null`() {
+        assertThat(LoopStepInferrer.infer("Launch the app")).isNull()
+    }
+
+    @Test
+    fun `text without until returns null`() {
+        assertThat(LoopStepInferrer.infer("Press D-pad down")).isNull()
+    }
+
+    @Test
+    fun `verb not in allowed list returns null`() {
+        assertThat(LoopStepInferrer.infer("Launch app until Home")).isNull()
+    }
+
+    @Test
+    fun `case insensitive verb matching`() {
+        val result = LoopStepInferrer.infer("NAVIGATE down until Home")
+        assertThat(result).isNotNull()
+    }
+
+    @Test
+    fun `move verb is recognized`() {
+        val result = LoopStepInferrer.infer("Move right until Search")
+        assertThat(result).isNotNull()
+        assertThat(result!!.action).isEqualTo("Move right")
+    }
+
+    @Test
+    fun `step verb is recognized`() {
+        val result = LoopStepInferrer.infer("Step through until Complete")
+        assertThat(result).isNotNull()
+    }
+
+    @Test
+    fun `go verb is recognized`() {
+        val result = LoopStepInferrer.infer("Go down until Footer")
+        assertThat(result).isNotNull()
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.parser.LoopStepInferrerTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.core.parser
+
+import me.chrisbanes.verity.core.model.JourneyStep
+
+object LoopStepInferrer {
+
+    private val LOOP_VERBS = setOf("press", "navigate", "move", "scroll", "go", "step")
+
+    // Matches: <action> until <condition> [up to N times]
+    private val PATTERN = Regex(
+        """^(.+?)\s+until\s+(.+?)(?:\s+up\s+to\s+(\d+)\s+times?)?\s*$""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    fun infer(text: String): JourneyStep.Loop? {
+        val match = PATTERN.matchEntire(text.trim()) ?: return null
+        val action = match.groupValues[1].trim()
+        val until = match.groupValues[2].trim()
+        val max = match.groupValues[3].takeIf { it.isNotEmpty() }?.toInt() ?: 20
+
+        // First word of action must be an allowed verb
+        val verb = action.split("\\s+".toRegex()).firstOrNull()?.lowercase() ?: return null
+        if (verb !in LOOP_VERBS) return null
+
+        return JourneyStep.Loop(action = action, until = until, max = max)
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.parser.LoopStepInferrerTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add LoopStepInferrer with NL pattern matching"
+```
+
+---
+
+### Task 7: AssertionStepInferrer
+
+Detects natural language assertion patterns: "Verify that...", "Ensure...", "Confirm...", "Check...".
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/parser/AssertionStepInferrer.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/parser/AssertionStepInferrerTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.parser
+
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isEqualTo
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.JourneyStep
+import kotlin.test.Test
+
+class AssertionStepInferrerTest {
+    @Test
+    fun `verify that pattern`() {
+        val result = AssertionStepInferrer.infer("Verify that Home is visible")
+        assertThat(result).isNotNull()
+        assertThat(result!!.description).isEqualTo("Home is visible")
+    }
+
+    @Test
+    fun `verify pattern without that`() {
+        val result = AssertionStepInferrer.infer("Verify Home is visible")
+        assertThat(result).isNotNull()
+        assertThat(result!!.description).isEqualTo("Home is visible")
+    }
+
+    @Test
+    fun `ensure pattern`() {
+        val result = AssertionStepInferrer.infer("Ensure the title appears")
+        assertThat(result).isNotNull()
+        assertThat(result!!.description).isEqualTo("the title appears")
+    }
+
+    @Test
+    fun `confirm pattern`() {
+        val result = AssertionStepInferrer.infer("Confirm detail page loaded")
+        assertThat(result).isNotNull()
+        assertThat(result!!.description).isEqualTo("detail page loaded")
+    }
+
+    @Test
+    fun `check pattern`() {
+        val result = AssertionStepInferrer.infer("Check that Settings is focused")
+        assertThat(result).isNotNull()
+        assertThat(result!!.description).isEqualTo("Settings is focused")
+    }
+
+    @Test
+    fun `case insensitive`() {
+        val result = AssertionStepInferrer.infer("VERIFY home screen")
+        assertThat(result).isNotNull()
+    }
+
+    @Test
+    fun `inferred mode uses AssertModeInferrer`() {
+        val result = AssertionStepInferrer.infer("Verify backdrop image is visible")
+        assertThat(result).isNotNull()
+        assertThat(result!!.mode).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `non-assertion returns null`() {
+        assertThat(AssertionStepInferrer.infer("Press D-pad down")).isNull()
+    }
+
+    @Test
+    fun `launch command is not an assertion`() {
+        assertThat(AssertionStepInferrer.infer("Launch the app")).isNull()
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.parser.AssertionStepInferrerTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.core.parser
+
+import me.chrisbanes.verity.core.model.JourneyStep
+
+object AssertionStepInferrer {
+
+    private val PATTERN = Regex(
+        """^(?:verify|ensure|confirm|check)\s+(?:that\s+)?(.+)$""",
+        RegexOption.IGNORE_CASE,
+    )
+
+    fun infer(text: String): JourneyStep.Assert? {
+        val match = PATTERN.matchEntire(text.trim()) ?: return null
+        val description = match.groupValues[1].trim()
+        val mode = AssertModeInferrer.infer(description)
+        return JourneyStep.Assert(description = description, mode = mode)
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.parser.AssertionStepInferrerTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add AssertionStepInferrer with NL keyword detection"
+```
+
+---
+
+### Task 8: JourneyStepSerializer — the `[?]` syntax parser
+
+This is the custom Kaml serializer that parses the step priority chain:
+1. `[?mode]` prefix → Assert with pinned mode
+2. `[?]` prefix → Assert with inferred mode
+3. Loop inference
+4. Assertion inference
+5. Default → Action
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/parser/JourneyStepSerializer.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/parser/JourneyStepSerializerTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.parser
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.JourneyStep
+import kotlin.test.Test
+
+class JourneyStepSerializerTest {
+    @Test
+    fun `parses explicit visual assertion`() {
+        val step = JourneyStepParser.parse("[?visual] Backdrop image loads")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        val assert = step as JourneyStep.Assert
+        assertThat(assert.mode).isEqualTo(AssertMode.VISUAL)
+        assertThat(assert.description).isEqualTo("Backdrop image loads")
+    }
+
+    @Test
+    fun `parses explicit tree assertion`() {
+        val step = JourneyStepParser.parse("[?tree] Synopsis has content")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        assertThat((step as JourneyStep.Assert).mode).isEqualTo(AssertMode.TREE)
+    }
+
+    @Test
+    fun `parses explicit visible assertion`() {
+        val step = JourneyStepParser.parse("[?visible] Home")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        assertThat((step as JourneyStep.Assert).mode).isEqualTo(AssertMode.VISIBLE)
+    }
+
+    @Test
+    fun `parses explicit focused assertion`() {
+        val step = JourneyStepParser.parse("[?focused] Settings")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        assertThat((step as JourneyStep.Assert).mode).isEqualTo(AssertMode.FOCUSED)
+    }
+
+    @Test
+    fun `parses generic assertion with inferred mode - short text`() {
+        val step = JourneyStepParser.parse("[?] Home")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        val assert = step as JourneyStep.Assert
+        assertThat(assert.description).isEqualTo("Home")
+        assertThat(assert.mode).isEqualTo(AssertMode.VISIBLE)
+    }
+
+    @Test
+    fun `parses generic assertion with inferred mode - long text`() {
+        val step = JourneyStepParser.parse("[?] Detail page shows title and synopsis")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        assertThat((step as JourneyStep.Assert).mode).isEqualTo(AssertMode.TREE)
+    }
+
+    @Test
+    fun `parses generic assertion with visual keywords`() {
+        val step = JourneyStepParser.parse("[?] Backdrop image is visible")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        assertThat((step as JourneyStep.Assert).mode).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `parses loop from NL`() {
+        val step = JourneyStepParser.parse("Navigate down until TV Shows row")
+        assertThat(step).isInstanceOf<JourneyStep.Loop>()
+        val loop = step as JourneyStep.Loop
+        assertThat(loop.action).isEqualTo("Navigate down")
+        assertThat(loop.until).isEqualTo("TV Shows row")
+    }
+
+    @Test
+    fun `parses NL assertion keyword`() {
+        val step = JourneyStepParser.parse("Verify that the title is visible")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        assertThat((step as JourneyStep.Assert).description).isEqualTo("the title is visible")
+    }
+
+    @Test
+    fun `parses plain action`() {
+        val step = JourneyStepParser.parse("Press D-pad down")
+        assertThat(step).isInstanceOf<JourneyStep.Action>()
+        assertThat((step as JourneyStep.Action).instruction).isEqualTo("Press D-pad down")
+    }
+
+    @Test
+    fun `parses launch as action not assertion`() {
+        val step = JourneyStepParser.parse("Launch the app")
+        assertThat(step).isInstanceOf<JourneyStep.Action>()
+    }
+
+    @Test
+    fun `explicit mode prefix takes priority over loop inference`() {
+        // Even though this has "until", the [?] prefix wins
+        val step = JourneyStepParser.parse("[?] Navigate down until TV Shows")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+    }
+
+    @Test
+    fun `loop inference takes priority over assertion inference`() {
+        // "Navigate" is a loop verb, takes priority over "Verify" check
+        val step = JourneyStepParser.parse("Navigate down until TV Shows row")
+        assertThat(step).isInstanceOf<JourneyStep.Loop>()
+    }
+
+    @Test
+    fun `trims whitespace`() {
+        val step = JourneyStepParser.parse("  [?]   Home   ")
+        assertThat(step).isInstanceOf<JourneyStep.Assert>()
+        assertThat((step as JourneyStep.Assert).description).isEqualTo("Home")
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.parser.JourneyStepSerializerTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+We need two things: a `JourneyStepParser` object (the pure parsing logic) and a `JourneyStepSerializer` (the Kaml integration).
+
+`JourneyStepSerializer.kt`:
+```kotlin
+package me.chrisbanes.verity.core.parser
+
+import com.charleskorn.kaml.YamlInput
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.JourneyStep
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Pure parsing logic for journey step strings. Used by the Kaml serializer
+ * and available for direct use in tests.
+ *
+ * Priority chain:
+ * 1. [?mode] prefix — pinned assertion mode
+ * 2. [?] prefix — inferred assertion mode
+ * 3. Loop inference — NL "verb ... until condition"
+ * 4. Assertion inference — NL "Verify/Ensure/Confirm/Check..."
+ * 5. Default — Action
+ */
+object JourneyStepParser {
+
+    private val PINNED_ASSERT = Regex(
+        """^\[\\?(\w+)]\s+(.+)$""",
+    )
+
+    private val GENERIC_ASSERT = Regex(
+        """^\[\\?]\s+(.+)$""",
+    )
+
+    // Use literal bracket patterns for YAML strings
+    private val PINNED_ASSERT_PATTERN = Regex(
+        """^\[\?(\w+)]\s+(.+)$""",
+    )
+
+    private val GENERIC_ASSERT_PATTERN = Regex(
+        """^\[\?]\s+(.+)$""",
+    )
+
+    private val MODE_MAP = mapOf(
+        "visual" to AssertMode.VISUAL,
+        "tree" to AssertMode.TREE,
+        "visible" to AssertMode.VISIBLE,
+        "focused" to AssertMode.FOCUSED,
+    )
+
+    fun parse(text: String): JourneyStep {
+        val trimmed = text.trim()
+
+        // 1. [?mode] prefix
+        PINNED_ASSERT_PATTERN.matchEntire(trimmed)?.let { match ->
+            val modeName = match.groupValues[1].lowercase()
+            val description = match.groupValues[2].trim()
+            val mode = MODE_MAP[modeName]
+                ?: error("Unknown assert mode: $modeName. Valid modes: ${MODE_MAP.keys}")
+            return JourneyStep.Assert(description = description, mode = mode)
+        }
+
+        // 2. [?] prefix
+        GENERIC_ASSERT_PATTERN.matchEntire(trimmed)?.let { match ->
+            val description = match.groupValues[1].trim()
+            val mode = AssertModeInferrer.infer(description)
+            return JourneyStep.Assert(description = description, mode = mode)
+        }
+
+        // 3. Loop inference
+        LoopStepInferrer.infer(trimmed)?.let { return it }
+
+        // 4. Assertion inference (NL keywords)
+        AssertionStepInferrer.infer(trimmed)?.let { return it }
+
+        // 5. Default: Action
+        return JourneyStep.Action(instruction = trimmed)
+    }
+}
+
+/**
+ * Kaml serializer that deserializes YAML string values into JourneyStep
+ * using JourneyStepParser.
+ */
+object JourneyStepSerializer : KSerializer<JourneyStep> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("JourneyStep", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): JourneyStep {
+        val text = decoder.decodeString()
+        return JourneyStepParser.parse(text)
+    }
+
+    override fun serialize(encoder: Encoder, value: JourneyStep) {
+        val text = when (value) {
+            is JourneyStep.Action -> value.instruction
+            is JourneyStep.Assert -> {
+                val modeStr = value.mode.name.lowercase()
+                "[?$modeStr] ${value.description}"
+            }
+            is JourneyStep.Loop -> {
+                val maxStr = if (value.max != 20) " up to ${value.max} times" else ""
+                "${value.action} until ${value.until}$maxStr"
+            }
+        }
+        encoder.encodeString(text)
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.parser.JourneyStepSerializerTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add JourneyStepParser and Kaml serializer for [?] syntax"
+```
+
+---
+
+### Task 9: Wire Journey with @Serializable and JourneyLoader
+
+Now that the serializer exists, annotate Journey and build the loader.
+
+**Files:**
+- Modify: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/model/Journey.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/journey/JourneyLoader.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/journey/JourneyLoaderTest.kt`
+- Create: `verity/core/src/test/resources/journeys/sample.journey.yaml`
+
+**Step 1: Update Journey with @Serializable**
+
+```kotlin
+package me.chrisbanes.verity.core.model
+
+import me.chrisbanes.verity.core.parser.JourneyStepSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Journey(
+    val name: String,
+    val app: String,
+    val platform: Platform,
+    val steps: List<@Serializable(with = JourneyStepSerializer::class) JourneyStep>,
+)
+```
+
+**Step 2: Create test journey file**
+
+`verity/core/src/test/resources/journeys/sample.journey.yaml`:
+```yaml
+name: Browse home and open detail
+app: com.example.launcher
+platform: android-tv
+
+steps:
+  - Launch the app
+  - "[?] Home"
+  - Navigate down until TV Shows row
+  - Press select
+  - "[?] Detail page shows title"
+  - "[?visual] Backdrop image loads"
+```
+
+Note: in YAML, strings starting with `[` must be quoted.
+
+**Step 3: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.journey
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.JourneyStep
+import me.chrisbanes.verity.core.model.Platform
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class JourneyLoaderTest {
+    @Test
+    fun `loads journey from YAML file`() {
+        val input = javaClass.classLoader.getResourceAsStream("journeys/sample.journey.yaml")!!
+        val yaml = input.bufferedReader().readText()
+        val journey = JourneyLoader.fromYaml(yaml)
+
+        assertThat(journey.name).isEqualTo("Browse home and open detail")
+        assertThat(journey.app).isEqualTo("com.example.launcher")
+        assertThat(journey.platform).isEqualTo(Platform.ANDROID_TV)
+        assertThat(journey.steps).hasSize(6)
+    }
+
+    @Test
+    fun `parses step types correctly`() {
+        val input = javaClass.classLoader.getResourceAsStream("journeys/sample.journey.yaml")!!
+        val journey = JourneyLoader.fromYaml(input.bufferedReader().readText())
+
+        assertThat(journey.steps[0]).isInstanceOf<JourneyStep.Action>()
+        assertThat(journey.steps[1]).isInstanceOf<JourneyStep.Assert>()
+        assertThat(journey.steps[2]).isInstanceOf<JourneyStep.Loop>()
+        assertThat(journey.steps[3]).isInstanceOf<JourneyStep.Action>()
+        assertThat(journey.steps[4]).isInstanceOf<JourneyStep.Assert>()
+        assertThat(journey.steps[5]).isInstanceOf<JourneyStep.Assert>()
+    }
+
+    @Test
+    fun `assert modes are inferred correctly`() {
+        val input = javaClass.classLoader.getResourceAsStream("journeys/sample.journey.yaml")!!
+        val journey = JourneyLoader.fromYaml(input.bufferedReader().readText())
+
+        // "[?] Home" → short text → VISIBLE
+        assertThat((journey.steps[1] as JourneyStep.Assert).mode).isEqualTo(AssertMode.VISIBLE)
+        // "[?] Detail page shows title" → long text → TREE
+        assertThat((journey.steps[4] as JourneyStep.Assert).mode).isEqualTo(AssertMode.TREE)
+        // "[?visual] Backdrop image loads" → pinned VISUAL
+        assertThat((journey.steps[5] as JourneyStep.Assert).mode).isEqualTo(AssertMode.VISUAL)
+    }
+
+    @Test
+    fun `lists journey files from directory`() {
+        val dir = File(javaClass.classLoader.getResource("journeys")!!.toURI())
+        val files = JourneyLoader.listJourneyFiles(dir)
+        assertThat(files).hasSize(1)
+        assertThat(files.first().name).isEqualTo("sample.journey.yaml")
+    }
+
+    @Test
+    fun `lists empty for directory with no journeys`() {
+        val tempDir = kotlin.io.path.createTempDirectory("empty-journeys").toFile()
+        try {
+            val files = JourneyLoader.listJourneyFiles(tempDir)
+            assertThat(files).isEmpty()
+        } finally {
+            tempDir.delete()
+        }
+    }
+}
+```
+
+**Step 4: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.journey.JourneyLoaderTest"`
+Expected: FAIL
+
+**Step 5: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.core.journey
+
+import com.charleskorn.kaml.Yaml
+import me.chrisbanes.verity.core.model.Journey
+import java.io.File
+
+object JourneyLoader {
+
+    private val yaml = Yaml.default
+
+    fun fromYaml(yamlText: String): Journey =
+        yaml.decodeFromString(Journey.serializer(), yamlText)
+
+    fun fromFile(file: File): Journey =
+        fromYaml(file.readText())
+
+    fun listJourneyFiles(directory: File): List<File> =
+        directory.listFiles()
+            ?.filter { it.isFile && it.name.endsWith(".journey.yaml") }
+            ?.sortedBy { it.name }
+            ?: emptyList()
+}
+```
+
+**Step 6: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.journey.JourneyLoaderTest"`
+Expected: PASS
+
+**Step 7: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add JourneyLoader with YAML deserialization"
+```
+
+---
+
+### Task 10: JourneySegmenter
+
+Splits a flat list of steps into execution segments at assertion/loop boundaries.
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/journey/JourneySegmenter.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/journey/JourneySegmenterTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.journey
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.JourneyStep
+import me.chrisbanes.verity.core.model.JourneyStep.*
+import kotlin.test.Test
+
+class JourneySegmenterTest {
+    @Test
+    fun `single action becomes one segment`() {
+        val steps = listOf(Action("Launch the app"))
+        val segments = JourneySegmenter.segment(steps)
+        assertThat(segments).hasSize(1)
+        assertThat(segments[0].actions).hasSize(1)
+        assertThat(segments[0].assertion).isNull()
+        assertThat(segments[0].loop).isNull()
+    }
+
+    @Test
+    fun `actions followed by assertion become one segment`() {
+        val steps = listOf(
+            Action("Launch the app"),
+            Action("Press D-pad down"),
+            Assert("Home", AssertMode.VISIBLE),
+        )
+        val segments = JourneySegmenter.segment(steps)
+        assertThat(segments).hasSize(1)
+        assertThat(segments[0].actions).hasSize(2)
+        assertThat(segments[0].assertion).isNotNull()
+        assertThat(segments[0].assertion!!.description).isEqualTo("Home")
+    }
+
+    @Test
+    fun `loop flushes pending actions then becomes its own segment`() {
+        val steps = listOf(
+            Action("Launch the app"),
+            Loop("Press D-pad down", "TV Shows"),
+        )
+        val segments = JourneySegmenter.segment(steps)
+        assertThat(segments).hasSize(2)
+        assertThat(segments[0].actions).hasSize(1)
+        assertThat(segments[0].loop).isNull()
+        assertThat(segments[1].actions).isEmpty()
+        assertThat(segments[1].loop).isNotNull()
+    }
+
+    @Test
+    fun `multiple assertion segments`() {
+        val steps = listOf(
+            Action("Launch the app"),
+            Assert("Home", AssertMode.VISIBLE),
+            Action("Press D-pad down"),
+            Assert("Settings", AssertMode.TREE),
+        )
+        val segments = JourneySegmenter.segment(steps)
+        assertThat(segments).hasSize(2)
+        assertThat(segments[0].index).isEqualTo(0)
+        assertThat(segments[1].index).isEqualTo(1)
+    }
+
+    @Test
+    fun `consecutive assertions create separate segments`() {
+        val steps = listOf(
+            Assert("Home", AssertMode.VISIBLE),
+            Assert("Movies", AssertMode.VISIBLE),
+        )
+        val segments = JourneySegmenter.segment(steps)
+        assertThat(segments).hasSize(2)
+        assertThat(segments[0].actions).isEmpty()
+        assertThat(segments[0].assertion!!.description).isEqualTo("Home")
+        assertThat(segments[1].actions).isEmpty()
+        assertThat(segments[1].assertion!!.description).isEqualTo("Movies")
+    }
+
+    @Test
+    fun `empty steps produce empty segments`() {
+        val segments = JourneySegmenter.segment(emptyList())
+        assertThat(segments).isEmpty()
+    }
+
+    @Test
+    fun `segment indices are sequential`() {
+        val steps = listOf(
+            Action("A"),
+            Assert("X", AssertMode.VISIBLE),
+            Action("B"),
+            Assert("Y", AssertMode.TREE),
+            Loop("Press down", "Z"),
+        )
+        val segments = JourneySegmenter.segment(steps)
+        segments.forEachIndexed { i, seg ->
+            assertThat(seg.index).isEqualTo(i)
+        }
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.journey.JourneySegmenterTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.core.journey
+
+import me.chrisbanes.verity.core.model.JourneySegment
+import me.chrisbanes.verity.core.model.JourneyStep
+
+object JourneySegmenter {
+
+    fun segment(steps: List<JourneyStep>): List<JourneySegment> {
+        val segments = mutableListOf<JourneySegment>()
+        val pendingActions = mutableListOf<JourneyStep.Action>()
+
+        for (step in steps) {
+            when (step) {
+                is JourneyStep.Action -> {
+                    pendingActions.add(step)
+                }
+                is JourneyStep.Assert -> {
+                    segments.add(
+                        JourneySegment(
+                            index = segments.size,
+                            actions = pendingActions.toList(),
+                            assertion = step,
+                        ),
+                    )
+                    pendingActions.clear()
+                }
+                is JourneyStep.Loop -> {
+                    // Flush pending actions as a separate segment
+                    if (pendingActions.isNotEmpty()) {
+                        segments.add(
+                            JourneySegment(
+                                index = segments.size,
+                                actions = pendingActions.toList(),
+                            ),
+                        )
+                        pendingActions.clear()
+                    }
+                    // Loop becomes its own segment
+                    segments.add(
+                        JourneySegment(
+                            index = segments.size,
+                            actions = emptyList(),
+                            loop = step,
+                        ),
+                    )
+                }
+            }
+        }
+
+        // Trailing actions without an assertion
+        if (pendingActions.isNotEmpty()) {
+            segments.add(
+                JourneySegment(
+                    index = segments.size,
+                    actions = pendingActions.toList(),
+                ),
+            )
+        }
+
+        return segments
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.journey.JourneySegmenterTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add JourneySegmenter for assertion-boundary splitting"
+```
+
+---
+
+### Task 11: PlatformKeyMapper
+
+Maps natural language key press instructions to platform-specific key names. When all actions in a segment map to known keys, the orchestrator can bypass LLM flow generation.
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/keymap/PlatformKeyMapper.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/keymap/AndroidTvKeyMapper.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/keymap/AndroidMobileKeyMapper.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/keymap/IosKeyMapper.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/keymap/PlatformKeyMapperTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.keymap
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.isNotNull
+import me.chrisbanes.verity.core.model.Platform
+import kotlin.test.Test
+
+class PlatformKeyMapperTest {
+
+    // Android TV tests
+    @Test
+    fun `android tv maps d-pad down`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("press d-pad down")).isEqualTo("Remote Dpad Down")
+    }
+
+    @Test
+    fun `android tv maps d-pad up`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("press d-pad up")).isEqualTo("Remote Dpad Up")
+    }
+
+    @Test
+    fun `android tv maps d-pad left`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("press d-pad left")).isEqualTo("Remote Dpad Left")
+    }
+
+    @Test
+    fun `android tv maps d-pad right`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("press d-pad right")).isEqualTo("Remote Dpad Right")
+    }
+
+    @Test
+    fun `android tv maps select`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("press select")).isEqualTo("Remote Dpad Center")
+    }
+
+    @Test
+    fun `android tv maps d-pad center`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("press d-pad center")).isEqualTo("Remote Dpad Center")
+    }
+
+    @Test
+    fun `android tv maps back`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("press back")).isEqualTo("back")
+    }
+
+    @Test
+    fun `android tv maps home`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("press home")).isEqualTo("home")
+    }
+
+    @Test
+    fun `android tv is case insensitive`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("Press D-Pad Down")).isEqualTo("Remote Dpad Down")
+    }
+
+    @Test
+    fun `android tv returns null for unknown action`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        assertThat(mapper.map("tap on the button")).isNull()
+    }
+
+    // Android Mobile tests
+    @Test
+    fun `android mobile maps back`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_MOBILE)
+        assertThat(mapper.map("press back")).isNotNull()
+    }
+
+    // iOS tests
+    @Test
+    fun `ios maps home`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.IOS)
+        assertThat(mapper.map("press home")).isNotNull()
+    }
+
+    // All actions mappable test
+    @Test
+    fun `allMappable returns true when all actions map`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        val actions = listOf("press d-pad down", "press d-pad down", "press select")
+        assertThat(mapper.allMappable(actions)).isEqualTo(true)
+    }
+
+    @Test
+    fun `allMappable returns false when any action is unmappable`() {
+        val mapper = PlatformKeyMapper.forPlatform(Platform.ANDROID_TV)
+        val actions = listOf("press d-pad down", "navigate to settings")
+        assertThat(mapper.allMappable(actions)).isEqualTo(false)
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.keymap.PlatformKeyMapperTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+`PlatformKeyMapper.kt`:
+```kotlin
+package me.chrisbanes.verity.core.keymap
+
+import me.chrisbanes.verity.core.model.Platform
+
+interface PlatformKeyMapper {
+    fun map(instruction: String): String?
+
+    fun allMappable(instructions: List<String>): Boolean =
+        instructions.all { map(it) != null }
+
+    companion object {
+        fun forPlatform(platform: Platform): PlatformKeyMapper = when (platform) {
+            Platform.ANDROID_TV -> AndroidTvKeyMapper
+            Platform.ANDROID_MOBILE -> AndroidMobileKeyMapper
+            Platform.IOS -> IosKeyMapper
+        }
+    }
+}
+```
+
+`AndroidTvKeyMapper.kt`:
+```kotlin
+package me.chrisbanes.verity.core.keymap
+
+object AndroidTvKeyMapper : PlatformKeyMapper {
+
+    private val KEY_MAP = mapOf(
+        "press d-pad down" to "Remote Dpad Down",
+        "press d-pad up" to "Remote Dpad Up",
+        "press d-pad left" to "Remote Dpad Left",
+        "press d-pad right" to "Remote Dpad Right",
+        "press d-pad center" to "Remote Dpad Center",
+        "press select" to "Remote Dpad Center",
+        "press enter" to "Remote Dpad Center",
+        "press back" to "back",
+        "press home" to "home",
+        "press menu" to "Remote Media Menu",
+        "press play" to "Remote Media Play Pause",
+        "press pause" to "Remote Media Play Pause",
+        "press rewind" to "Remote Media Rewind",
+        "press fast forward" to "Remote Media Fast Forward",
+    )
+
+    override fun map(instruction: String): String? =
+        KEY_MAP[instruction.trim().lowercase()]
+}
+```
+
+`AndroidMobileKeyMapper.kt`:
+```kotlin
+package me.chrisbanes.verity.core.keymap
+
+object AndroidMobileKeyMapper : PlatformKeyMapper {
+
+    private val KEY_MAP = mapOf(
+        "press back" to "back",
+        "press home" to "home",
+        "press enter" to "enter",
+        "press volume up" to "volume up",
+        "press volume down" to "volume down",
+    )
+
+    override fun map(instruction: String): String? =
+        KEY_MAP[instruction.trim().lowercase()]
+}
+```
+
+`IosKeyMapper.kt`:
+```kotlin
+package me.chrisbanes.verity.core.keymap
+
+object IosKeyMapper : PlatformKeyMapper {
+
+    private val KEY_MAP = mapOf(
+        "press home" to "home",
+        "press lock" to "lock",
+        "press volume up" to "volume up",
+        "press volume down" to "volume down",
+    )
+
+    override fun map(instruction: String): String? =
+        KEY_MAP[instruction.trim().lowercase()]
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.keymap.PlatformKeyMapperTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add PlatformKeyMapper with Android TV/Mobile and iOS key maps"
+```
+
+---
+
+### Task 12: HierarchyFilter and HierarchyRenderer
+
+Renders an accessibility tree to indented text with configurable attribute filtering. The device layer will call this with platform-specific tree data, but the rendering logic itself is pure string processing.
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/hierarchy/HierarchyFilter.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/hierarchy/HierarchyNode.kt`
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/hierarchy/HierarchyRenderer.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/hierarchy/HierarchyRendererTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.hierarchy
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class HierarchyRendererTest {
+
+    private fun node(
+        attributes: Map<String, String> = emptyMap(),
+        states: Set<String> = emptySet(),
+        children: List<HierarchyNode> = emptyList(),
+    ) = HierarchyNode(attributes, states, children)
+
+    @Test
+    fun `renders single node with text`() {
+        val tree = node(attributes = mapOf("text" to "Home"))
+        val result = HierarchyRenderer.render(tree, HierarchyFilter.CONTENT)
+        assertThat(result).contains("[text=Home]")
+    }
+
+    @Test
+    fun `renders states as suffix`() {
+        val tree = node(
+            attributes = mapOf("text" to "Settings"),
+            states = setOf("focused", "clickable"),
+        )
+        val result = HierarchyRenderer.render(tree, HierarchyFilter.CONTENT)
+        assertThat(result).contains("(focused,clickable)")
+    }
+
+    @Test
+    fun `renders children indented`() {
+        val tree = node(
+            attributes = mapOf("text" to "Nav"),
+            children = listOf(
+                node(attributes = mapOf("text" to "Home")),
+                node(attributes = mapOf("text" to "Settings")),
+            ),
+        )
+        val result = HierarchyRenderer.render(tree, HierarchyFilter.CONTENT)
+        assertThat(result).contains("  [text=Home]")
+        assertThat(result).contains("  [text=Settings]")
+    }
+
+    @Test
+    fun `FOCUS filter excludes bounds`() {
+        val tree = node(
+            attributes = mapOf("text" to "Home", "bounds" to "[0,0][100,50]"),
+        )
+        val result = HierarchyRenderer.render(tree, HierarchyFilter.FOCUS)
+        assertThat(result).doesNotContain("bounds")
+    }
+
+    @Test
+    fun `CONTENT filter includes bounds`() {
+        val tree = node(
+            attributes = mapOf("text" to "Home", "bounds" to "[0,0][100,50]"),
+        )
+        val result = HierarchyRenderer.render(tree, HierarchyFilter.CONTENT)
+        assertThat(result).contains("bounds")
+    }
+
+    @Test
+    fun `ALL filter includes everything`() {
+        val tree = node(
+            attributes = mapOf("text" to "X", "class" to "android.widget.TextView"),
+        )
+        val result = HierarchyRenderer.render(tree, HierarchyFilter.ALL)
+        assertThat(result).contains("class=android.widget.TextView")
+    }
+
+    @Test
+    fun `strips empty string attributes`() {
+        val tree = node(
+            attributes = mapOf("text" to "Home", "resource-id" to ""),
+        )
+        val result = HierarchyRenderer.render(tree, HierarchyFilter.ALL)
+        assertThat(result).doesNotContain("resource-id")
+    }
+
+    @Test
+    fun `collapses empty container with single child`() {
+        val container = node(
+            children = listOf(
+                node(attributes = mapOf("text" to "Home")),
+            ),
+        )
+        val result = HierarchyRenderer.render(container, HierarchyFilter.CONTENT)
+        // Child should render at depth 0, not indented under empty container
+        assertThat(result.trimEnd()).isEqualTo("[text=Home]")
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.hierarchy.HierarchyRendererTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+`HierarchyFilter.kt`:
+```kotlin
+package me.chrisbanes.verity.core.hierarchy
+
+enum class HierarchyFilter(val allowedKeys: Set<String>?) {
+    FOCUS(setOf("text", "resource-id", "selected")),
+    CONTENT(setOf("text", "accessibilityText", "resource-id", "bounds")),
+    ALL(null), // null = allow all
+}
+```
+
+`HierarchyNode.kt`:
+```kotlin
+package me.chrisbanes.verity.core.hierarchy
+
+/**
+ * Platform-agnostic representation of an accessibility tree node.
+ * The device layer converts platform-specific trees into this format.
+ */
+data class HierarchyNode(
+    val attributes: Map<String, String> = emptyMap(),
+    val states: Set<String> = emptySet(),
+    val children: List<HierarchyNode> = emptyList(),
+)
+```
+
+`HierarchyRenderer.kt`:
+```kotlin
+package me.chrisbanes.verity.core.hierarchy
+
+object HierarchyRenderer {
+
+    fun render(root: HierarchyNode, filter: HierarchyFilter): String {
+        val sb = StringBuilder()
+        renderNode(root, filter, depth = 0, sb)
+        return sb.toString()
+    }
+
+    private fun renderNode(
+        node: HierarchyNode,
+        filter: HierarchyFilter,
+        depth: Int,
+        sb: StringBuilder,
+    ) {
+        val filteredAttrs = node.attributes
+            .filter { (_, v) -> v.isNotEmpty() && v != "false" }
+            .filter { (k, v) -> !(k == "enabled" && v == "true") }
+            .filter { (k, _) -> filter.allowedKeys == null || k in filter.allowedKeys }
+
+        val hasContent = filteredAttrs.isNotEmpty() || node.states.isNotEmpty()
+
+        // Collapse empty containers with 0 or 1 children
+        if (!hasContent && node.children.size <= 1) {
+            for (child in node.children) {
+                renderNode(child, filter, depth, sb)
+            }
+            return
+        }
+
+        if (hasContent) {
+            val indent = "  ".repeat(depth)
+            val attrStr = filteredAttrs.entries.joinToString(", ") { "${it.key}=${it.value}" }
+            val stateStr = if (node.states.isNotEmpty()) {
+                " (${node.states.sorted().joinToString(",")})"
+            } else ""
+
+            sb.appendLine("$indent[$attrStr]$stateStr")
+        }
+
+        for (child in node.children) {
+            renderNode(child, filter, if (hasContent) depth + 1 else depth, sb)
+        }
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.hierarchy.HierarchyRendererTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add HierarchyNode, HierarchyFilter, and HierarchyRenderer"
+```
+
+---
+
+### Task 13: Focus detection — hierarchyContainsFocused
+
+Lenient algorithm that checks ancestor, descendant, and sibling relationships between focused nodes and text matches in rendered hierarchy text.
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/hierarchy/FocusDetector.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/hierarchy/FocusDetectorTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.hierarchy
+
+import assertk.assertThat
+import assertk.assertions.isTrue
+import assertk.assertions.isFalse
+import kotlin.test.Test
+
+class FocusDetectorTest {
+
+    @Test
+    fun `text on focused node`() {
+        val hierarchy = """
+            [text=Home] (focused)
+            [text=Settings]
+        """.trimIndent()
+        assertThat(FocusDetector.containsFocused(hierarchy, "Home")).isTrue()
+    }
+
+    @Test
+    fun `text not on focused node`() {
+        val hierarchy = """
+            [text=Home] (focused)
+            [text=Settings]
+        """.trimIndent()
+        assertThat(FocusDetector.containsFocused(hierarchy, "Settings")).isFalse()
+    }
+
+    @Test
+    fun `text on descendant of focused node`() {
+        val hierarchy = """
+            [resource-id=card] (focused)
+              [text=Movie Title]
+              [text=2024]
+        """.trimIndent()
+        assertThat(FocusDetector.containsFocused(hierarchy, "Movie Title")).isTrue()
+    }
+
+    @Test
+    fun `text on sibling of focused node`() {
+        val hierarchy = """
+            [resource-id=container]
+              [resource-id=focus-indicator] (focused)
+              [text=Movie Title]
+        """.trimIndent()
+        assertThat(FocusDetector.containsFocused(hierarchy, "Movie Title")).isTrue()
+    }
+
+    @Test
+    fun `text on ancestor of focused node is not a match`() {
+        // Focus is on a child but the text is on the parent — this means
+        // the parent row has focus, so it should match
+        val hierarchy = """
+            [text=Row Title]
+              [resource-id=item] (focused)
+        """.trimIndent()
+        assertThat(FocusDetector.containsFocused(hierarchy, "Row Title")).isTrue()
+    }
+
+    @Test
+    fun `no focused node returns false`() {
+        val hierarchy = """
+            [text=Home]
+            [text=Settings]
+        """.trimIndent()
+        assertThat(FocusDetector.containsFocused(hierarchy, "Home")).isFalse()
+    }
+
+    @Test
+    fun `case insensitive text matching`() {
+        val hierarchy = "[text=Home] (focused)"
+        assertThat(FocusDetector.containsFocused(hierarchy, "home")).isTrue()
+    }
+
+    @Test
+    fun `empty hierarchy returns false`() {
+        assertThat(FocusDetector.containsFocused("", "anything")).isFalse()
+    }
+
+    @Test
+    fun `deeply nested descendant of focused node`() {
+        val hierarchy = """
+            [resource-id=card] (focused)
+              [resource-id=inner]
+                [text=Deep Text]
+        """.trimIndent()
+        assertThat(FocusDetector.containsFocused(hierarchy, "Deep Text")).isTrue()
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.hierarchy.FocusDetectorTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.core.hierarchy
+
+/**
+ * Lenient focus detection for accessibility trees.
+ *
+ * Android TV often places `focused=true` on a container while the actual
+ * text lives in a sibling or child. This algorithm checks multiple
+ * relationship types between focused nodes and text nodes.
+ */
+object FocusDetector {
+
+    private data class ParsedNode(
+        val depth: Int,
+        val focused: Boolean,
+        val text: String,  // the raw line content
+    )
+
+    fun containsFocused(hierarchy: String, text: String): Boolean {
+        if (hierarchy.isBlank()) return false
+
+        val nodes = hierarchy.lines()
+            .filter { it.isNotBlank() }
+            .map { line ->
+                val depth = line.length - line.trimStart().length
+                val focused = line.contains("(focused") || line.contains(",focused")
+                ParsedNode(depth = depth / 2, focused = focused, text = line)
+            }
+
+        val textLower = text.lowercase()
+        val focusedIndices = nodes.indices.filter { nodes[it].focused }
+        val textIndices = nodes.indices.filter { nodes[it].text.lowercase().contains(textLower) }
+
+        if (focusedIndices.isEmpty() || textIndices.isEmpty()) return false
+
+        for (fi in focusedIndices) {
+            for (ti in textIndices) {
+                if (fi == ti) return true  // Same node
+                if (isDescendant(nodes, parent = fi, child = ti)) return true
+                if (isDescendant(nodes, parent = ti, child = fi)) return true  // Ancestor of focused
+                if (isSibling(nodes, fi, ti)) return true
+            }
+        }
+        return false
+    }
+
+    private fun isDescendant(nodes: List<ParsedNode>, parent: Int, child: Int): Boolean {
+        if (child <= parent) return false
+        if (nodes[child].depth <= nodes[parent].depth) return false
+        // Check that no node between parent and child is at parent's depth or shallower
+        for (i in (parent + 1) until child) {
+            if (nodes[i].depth <= nodes[parent].depth) return false
+        }
+        return true
+    }
+
+    private fun isSibling(nodes: List<ParsedNode>, a: Int, b: Int): Boolean {
+        if (nodes[a].depth != nodes[b].depth) return false
+        val (first, second) = if (a < b) a to b else b to a
+        // Siblings share the same parent — no node between them is at a shallower depth
+        for (i in (first + 1) until second) {
+            if (nodes[i].depth < nodes[first].depth) return false
+        }
+        return true
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.hierarchy.FocusDetectorTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add FocusDetector with lenient ancestor/sibling/descendant checking"
+```
+
+---
+
+### Task 14: ContextLoader
+
+Loads markdown context files from a directory. Used by both CLI and MCP for optional app-specific context injection (defaults are bundled elsewhere).
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/context/ContextLoader.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/context/ContextLoaderTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.core.context
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEmpty
+import assertk.assertions.isNotEmpty
+import java.io.File
+import kotlin.test.Test
+
+class ContextLoaderTest {
+
+    @Test
+    fun `loads markdown files from directory`() {
+        val dir = createTempContextDir(
+            "app.md" to "# App\nLauncher app context",
+            "maestro.md" to "# Maestro\nMaestro commands",
+        )
+        try {
+            val context = ContextLoader.load(dir)
+            assertThat(context).contains("# App")
+            assertThat(context).contains("# Maestro")
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `ignores non-markdown files`() {
+        val dir = createTempContextDir(
+            "app.md" to "# App context",
+            "notes.txt" to "Should be ignored",
+        )
+        try {
+            val context = ContextLoader.load(dir)
+            assertThat(context).contains("# App context")
+            assertThat(context.contains("Should be ignored")).isEqualTo(false)
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `returns empty string for empty directory`() {
+        val dir = kotlin.io.path.createTempDirectory("empty-context").toFile()
+        try {
+            assertThat(ContextLoader.load(dir)).isEmpty()
+        } finally {
+            dir.delete()
+        }
+    }
+
+    @Test
+    fun `returns empty string for nonexistent directory`() {
+        assertThat(ContextLoader.load(File("/nonexistent/path"))).isEmpty()
+    }
+
+    @Test
+    fun `files are separated by double newline`() {
+        val dir = createTempContextDir(
+            "a.md" to "Section A",
+            "b.md" to "Section B",
+        )
+        try {
+            val context = ContextLoader.load(dir)
+            assertThat(context).contains("\n\n")
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    private fun createTempContextDir(vararg files: Pair<String, String>): File {
+        val dir = kotlin.io.path.createTempDirectory("context-test").toFile()
+        for ((name, content) in files) {
+            File(dir, name).writeText(content)
+        }
+        return dir
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.context.ContextLoaderTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.core.context
+
+import java.io.File
+
+object ContextLoader {
+
+    fun load(directory: File): String {
+        if (!directory.isDirectory) return ""
+
+        return directory.listFiles()
+            ?.filter { it.isFile && it.extension == "md" }
+            ?.sortedBy { it.name }
+            ?.joinToString("\n\n") { it.readText().trim() }
+            ?: ""
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.context.ContextLoaderTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/core/src/
+git commit -m "feat(core): add ContextLoader for markdown context files"
+```
+
+---
+
+### Task 15: Run all core tests
+
+**Step 1: Run the full core test suite**
+
+```bash
+./gradlew :verity:core:test
+```
+
+Expected: ALL PASS
+
+**Step 2: Commit if any cleanup was needed, otherwise skip**
+
+---
+
+## Verification
+
+After all tasks, `:verity:core` should contain:
+
+```
+verity/core/src/main/kotlin/me/chrisbanes/verity/core/
+├── model/
+│   ├── Platform.kt
+│   ├── AssertMode.kt
+│   ├── JourneyStep.kt
+│   ├── Journey.kt
+│   ├── JourneySegment.kt
+│   ├── FlowResult.kt
+│   └── InspectionVerdict.kt
+├── parser/
+│   ├── AssertModeInferrer.kt
+│   ├── LoopStepInferrer.kt
+│   ├── AssertionStepInferrer.kt
+│   └── JourneyStepSerializer.kt (includes JourneyStepParser)
+├── journey/
+│   ├── JourneyLoader.kt
+│   └── JourneySegmenter.kt
+├── keymap/
+│   ├── PlatformKeyMapper.kt
+│   ├── AndroidTvKeyMapper.kt
+│   ├── AndroidMobileKeyMapper.kt
+│   └── IosKeyMapper.kt
+├── hierarchy/
+│   ├── HierarchyFilter.kt
+│   ├── HierarchyNode.kt
+│   ├── HierarchyRenderer.kt
+│   └── FocusDetector.kt
+└── context/
+    └── ContextLoader.kt
+```
+
+All tests passing. Zero device or LLM SDK dependencies.

--- a/docs/plans/2026-03-11-phase-2-device.md
+++ b/docs/plans/2026-03-11-phase-2-device.md
@@ -1,0 +1,510 @@
+# Phase 2: `:verity:device` — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the device abstraction layer with the `DeviceSession` interface and platform-specific implementations for Android (Dadb + Maestro gRPC) and iOS (Maestro XCTest HTTP).
+
+**Architecture:** A single `DeviceSession` interface defines all device operations. `AndroidDeviceSession` wraps Dadb for ADB communication and Maestro's `AndroidDriver` for gRPC-based UI automation. `IosDeviceSession` wraps Maestro's XCTest HTTP client. `DeviceSessionFactory` handles connection, auto-discovery, and animation management.
+
+**Tech Stack:** Maestro SDK (`dev.mobile:maestro-client`), Dadb (`dev.mobile:dadb`), Maestro iOS driver (`dev.mobile:maestro-ios-driver`), grpc-netty-shaded
+
+**Design doc:** `docs/plans/2026-03-11-verity-design.md`
+
+**Prerequisite:** Phase 0 and Phase 1 complete.
+
+**Important:** This module depends on the Maestro SDK, which is not well-documented for embedded use. You may need to explore the Maestro source code to confirm exact class names and method signatures. The key classes to look for are: `Maestro`, `MaestroDriver`, `AndroidDriver`, `Orchestra`, `MaestroFlowParser`, `ViewHierarchy`, `TreeNode`.
+
+**Delivery mode (required):**
+- **Scaffold milestone:** It is acceptable to land structure with temporary `TODO()` stubs while SDK surfaces are being validated.
+- **Production-ready milestone:** No `TODO()` remains in `:verity:device` production sources. Android and iOS paths are both wired against real SDK types and run through at least one device-backed smoke check.
+
+### Task 0: SDK validation spike (must happen first)
+
+**Goal:** remove class/method signature uncertainty before writing production code.
+
+**Steps:**
+1. Verify Maestro Android APIs used by this phase (`Maestro`, `AndroidDriver`, flow parser/orchestra classes, hierarchy capture, screenshot, wait-for-animation).
+2. Verify Maestro iOS APIs (`IOSDriver`, XCTest installer/client, hierarchy/screenshot APIs).
+3. Write a short compatibility note (in this file) listing any naming or API differences from assumptions in Tasks 2–4.
+4. Update the code snippets in this plan before implementation if mismatches are found.
+
+---
+
+### Task 1: DeviceSession interface
+
+**Files:**
+- Create: `verity/device/src/main/kotlin/me/chrisbanes/verity/device/DeviceSession.kt`
+
+**Step 1: Write the interface**
+
+```kotlin
+package me.chrisbanes.verity.device
+
+import me.chrisbanes.verity.core.hierarchy.HierarchyFilter
+import me.chrisbanes.verity.core.hierarchy.HierarchyNode
+import me.chrisbanes.verity.core.model.FlowResult
+import me.chrisbanes.verity.core.model.Platform
+import java.io.File
+
+interface DeviceSession : AutoCloseable {
+    val platform: Platform
+
+    data class AnimationState(
+        val windowScale: String,
+        val transitionScale: String,
+        val animatorScale: String,
+    )
+
+    /** Execute a Maestro YAML flow against the device. */
+    suspend fun executeFlow(yaml: String): FlowResult
+
+    /** Press a single key by its platform key name (from PlatformKeyMapper). */
+    suspend fun pressKey(keyName: String)
+
+    /** Capture the accessibility tree as a HierarchyNode. */
+    suspend fun captureHierarchyTree(filter: HierarchyFilter = HierarchyFilter.CONTENT): HierarchyNode
+
+    /** Capture and render the accessibility tree as indented text. */
+    suspend fun captureHierarchy(filter: HierarchyFilter = HierarchyFilter.CONTENT): String
+
+    /** Save a screenshot to the specified file. */
+    suspend fun captureScreenshot(outputFile: File)
+
+    /** Check if text appears anywhere in the accessibility tree. */
+    suspend fun containsText(text: String, ignoreCase: Boolean = true): Boolean
+
+    /** Check if text appears on or near a focused node (lenient). */
+    suspend fun checkFocused(text: String): Boolean
+
+    /** Execute a shell command on the device. */
+    suspend fun shell(command: String): String
+
+    /** Wait for any in-progress animations to finish. */
+    suspend fun waitForAnimationToEnd()
+
+    /**
+     * Android-only animation controls.
+     *
+     * Default implementations are no-op for platforms that don't expose
+     * Android global animation scale settings.
+     */
+    suspend fun saveAnimationState(): AnimationState? = null
+    suspend fun disableAnimations() = Unit
+    suspend fun restoreAnimationState(state: AnimationState) = Unit
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/device/src/
+git commit -m "feat(device): add DeviceSession interface"
+```
+
+---
+
+### Task 2: AndroidDeviceSession
+
+This is the most complex class. It wraps Dadb + Maestro SDK.
+
+**Files:**
+- Create: `verity/device/src/main/kotlin/me/chrisbanes/verity/device/android/AndroidDeviceSession.kt`
+- Create: `verity/device/src/main/kotlin/me/chrisbanes/verity/device/android/MaestroTreeConverter.kt`
+
+**Step 1: Write MaestroTreeConverter**
+
+Converts Maestro's `TreeNode` (or `ViewHierarchy`) into our `HierarchyNode`.
+
+```kotlin
+package me.chrisbanes.verity.device.android
+
+import me.chrisbanes.verity.core.hierarchy.HierarchyNode
+import maestro.TreeNode
+
+/**
+ * Converts Maestro's TreeNode into our platform-agnostic HierarchyNode.
+ *
+ * NOTE: Verify the exact TreeNode API against the Maestro SDK source.
+ * Key fields expected: attributes (Map<String, String>), children (List<TreeNode>),
+ * and boolean properties like focused, selected, clickable, enabled, checked.
+ */
+object MaestroTreeConverter {
+
+    fun convert(node: TreeNode): HierarchyNode {
+        val attributes = node.attributes
+            .filterValues { it.isNotEmpty() }
+
+        val states = buildSet {
+            if (node.focused == true) add("focused")
+            if (node.selected == true) add("selected")
+            if (node.checked == true) add("checked")
+            if (node.enabled == false) add("disabled")
+            if (node.clickable == true) add("clickable")
+        }
+
+        return HierarchyNode(
+            attributes = attributes,
+            states = states,
+            children = node.children.map { convert(it) },
+        )
+    }
+}
+```
+
+**Note:** The exact `TreeNode` property names (`focused`, `selected`, `clickable`, `attributes`) must be verified against the Maestro SDK. Check `maestro.TreeNode` in the SDK source.
+
+**Step 2: Write AndroidDeviceSession**
+
+```kotlin
+package me.chrisbanes.verity.device.android
+
+import me.chrisbanes.verity.core.hierarchy.FocusDetector
+import me.chrisbanes.verity.core.hierarchy.HierarchyFilter
+import me.chrisbanes.verity.core.hierarchy.HierarchyNode
+import me.chrisbanes.verity.core.hierarchy.HierarchyRenderer
+import me.chrisbanes.verity.core.model.FlowResult
+import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.device.DeviceSession
+import dadb.Dadb
+import java.io.File
+
+/**
+ * Android device session backed by Dadb (ADB over TCP) and Maestro SDK (gRPC).
+ *
+ * NOTE: This implementation references Maestro SDK classes whose exact APIs
+ * should be verified against the SDK source code. Key classes:
+ * - maestro.Maestro — main entry, provides viewHierarchy(), pressKey(), etc.
+ * - maestro.drivers.AndroidDriver — connects via gRPC to the on-device agent
+ * - maestro.orchestra.Orchestra — executes parsed flows
+ * - maestro.orchestra.yaml.YamlFlowParser — parses YAML into MaestroCommand lists
+ */
+class AndroidDeviceSession(
+    private val dadb: Dadb,
+    private val maestro: Any, // Replace with actual Maestro type
+    override val platform: Platform,
+) : DeviceSession {
+
+    override suspend fun executeFlow(yaml: String): FlowResult {
+        // 1. Parse YAML with MaestroFlowParser
+        // 2. Execute commands through Orchestra
+        // 3. Return FlowResult(success, output)
+        TODO("Wire Maestro SDK flow execution — parse YAML, execute via Orchestra")
+    }
+
+    override suspend fun pressKey(keyName: String) {
+        // maestro.pressKey(keyName) or equivalent
+        TODO("Wire Maestro SDK key press")
+    }
+
+    override suspend fun captureHierarchyTree(filter: HierarchyFilter): HierarchyNode {
+        // val viewHierarchy = maestro.viewHierarchy()
+        // return MaestroTreeConverter.convert(viewHierarchy.root)
+        TODO("Wire Maestro SDK hierarchy capture")
+    }
+
+    override suspend fun captureHierarchy(filter: HierarchyFilter): String {
+        val tree = captureHierarchyTree(filter)
+        return HierarchyRenderer.render(tree, filter)
+    }
+
+    override suspend fun captureScreenshot(outputFile: File) {
+        // maestro.takeScreenshot(outputFile) or dadb equivalent
+        TODO("Wire Maestro SDK or ADB screenshot")
+    }
+
+    override suspend fun containsText(text: String, ignoreCase: Boolean): Boolean {
+        val hierarchy = captureHierarchy(HierarchyFilter.CONTENT)
+        return if (ignoreCase) {
+            hierarchy.lowercase().contains(text.lowercase())
+        } else {
+            hierarchy.contains(text)
+        }
+    }
+
+    override suspend fun checkFocused(text: String): Boolean {
+        val hierarchy = captureHierarchy(HierarchyFilter.FOCUS)
+        return FocusDetector.containsFocused(hierarchy, text)
+    }
+
+    override suspend fun shell(command: String): String {
+        val response = dadb.shell(command)
+        return response.output
+    }
+
+    override suspend fun waitForAnimationToEnd() {
+        // maestro.waitForAnimationToEnd() or equivalent
+        TODO("Wire Maestro SDK animation wait")
+    }
+
+    override fun close() {
+        // maestro.close()
+        // dadb.close()
+        TODO("Close Maestro and Dadb connections")
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add verity/device/src/
+git commit -m "feat(device): add AndroidDeviceSession with Maestro SDK structure"
+```
+
+---
+
+### Task 3: IosDeviceSession
+
+**Files:**
+- Create: `verity/device/src/main/kotlin/me/chrisbanes/verity/device/ios/IosDeviceSession.kt`
+- Create: `verity/device/src/main/kotlin/me/chrisbanes/verity/device/ios/XcTestTreeConverter.kt`
+
+**Step 1: Write IosDeviceSession**
+
+```kotlin
+package me.chrisbanes.verity.device.ios
+
+import me.chrisbanes.verity.core.hierarchy.FocusDetector
+import me.chrisbanes.verity.core.hierarchy.HierarchyFilter
+import me.chrisbanes.verity.core.hierarchy.HierarchyNode
+import me.chrisbanes.verity.core.hierarchy.HierarchyRenderer
+import me.chrisbanes.verity.core.model.FlowResult
+import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.device.DeviceSession
+import java.io.File
+
+/**
+ * iOS device session backed by Maestro's XCTest HTTP client.
+ *
+ * The XCTest runner exposes an HTTP server on the device/simulator at port 22087.
+ * Maestro's iOS driver communicates via JSON POST requests.
+ *
+ * Key classes to reference from Maestro SDK:
+ * - maestro.drivers.IOSDriver
+ * - XCTestDriverClient (HTTP client for the on-device XCTest server)
+ * - LocalXCTestInstaller (manages XCTest runner lifecycle)
+ */
+class IosDeviceSession(
+    private val iosDriver: Any, // Replace with actual Maestro IOSDriver type
+) : DeviceSession {
+
+    override val platform: Platform = Platform.IOS
+
+    override suspend fun executeFlow(yaml: String): FlowResult {
+        TODO("Wire Maestro iOS flow execution")
+    }
+
+    override suspend fun pressKey(keyName: String) {
+        TODO("Wire iOS key press / gesture")
+    }
+
+    override suspend fun captureHierarchyTree(filter: HierarchyFilter): HierarchyNode {
+        // val hierarchy = iosDriver.viewHierarchy()
+        // return XcTestTreeConverter.convert(hierarchy)
+        TODO("Wire Maestro iOS hierarchy capture")
+    }
+
+    override suspend fun captureHierarchy(filter: HierarchyFilter): String {
+        val tree = captureHierarchyTree(filter)
+        return HierarchyRenderer.render(tree, filter)
+    }
+
+    override suspend fun captureScreenshot(outputFile: File) {
+        TODO("Wire Maestro iOS screenshot")
+    }
+
+    override suspend fun containsText(text: String, ignoreCase: Boolean): Boolean {
+        val hierarchy = captureHierarchy(HierarchyFilter.CONTENT)
+        return if (ignoreCase) {
+            hierarchy.lowercase().contains(text.lowercase())
+        } else {
+            hierarchy.contains(text)
+        }
+    }
+
+    override suspend fun checkFocused(text: String): Boolean {
+        val hierarchy = captureHierarchy(HierarchyFilter.FOCUS)
+        return FocusDetector.containsFocused(hierarchy, text)
+    }
+
+    override suspend fun shell(command: String): String {
+        TODO("Wire iOS shell command (xcrun simctl or devicectl)")
+    }
+
+    override suspend fun waitForAnimationToEnd() {
+        TODO("Wire Maestro iOS animation wait")
+    }
+
+    override fun close() {
+        TODO("Close iOS driver")
+    }
+}
+```
+
+**Step 2: Write XcTestTreeConverter placeholder**
+
+```kotlin
+package me.chrisbanes.verity.device.ios
+
+import me.chrisbanes.verity.core.hierarchy.HierarchyNode
+
+/**
+ * Converts Maestro's iOS view hierarchy into our platform-agnostic HierarchyNode.
+ *
+ * NOTE: Verify the iOS hierarchy format from Maestro's XCTest driver.
+ * The structure should be similar to Android's TreeNode but with iOS-specific
+ * accessibility attributes (label, value, identifier, traits).
+ */
+object XcTestTreeConverter {
+
+    fun convert(node: Any): HierarchyNode {
+        TODO("Implement iOS tree conversion — examine Maestro IOSDriver.viewHierarchy() return type")
+    }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add verity/device/src/
+git commit -m "feat(device): add IosDeviceSession with XCTest HTTP structure"
+```
+
+---
+
+### Task 4: DeviceSessionFactory
+
+**Files:**
+- Create: `verity/device/src/main/kotlin/me/chrisbanes/verity/device/DeviceSessionFactory.kt`
+
+**Step 1: Write the factory**
+
+```kotlin
+package me.chrisbanes.verity.device
+
+import me.chrisbanes.verity.core.model.Platform
+
+/**
+ * Creates DeviceSession instances with auto-discovery and animation management.
+ *
+ * When disableAnimations=true:
+ * - Saves current animation scale values
+ * - Sets window_animation_scale, transition_animation_scale,
+ *   animator_duration_scale to 0
+ * - Restores original values when session is closed
+ */
+object DeviceSessionFactory {
+    suspend fun connect(
+        platform: Platform,
+        deviceId: String? = null,
+        disableAnimations: Boolean = false,
+    ): DeviceSession {
+        return when (platform) {
+            Platform.ANDROID_TV, Platform.ANDROID_MOBILE -> connectAndroid(platform, deviceId, disableAnimations)
+            Platform.IOS -> connectIos(deviceId, disableAnimations)
+        }
+    }
+
+    private suspend fun connectAndroid(
+        platform: Platform,
+        deviceId: String?,
+        disableAnimations: Boolean,
+    ): DeviceSession {
+        // 1. Connect via Dadb
+        //    val dadb = if (deviceId != null) Dadb.connect(deviceId) else Dadb.discover()
+        // 2. Create AndroidDriver → Maestro instance
+        // 3. Return AndroidDeviceSession(dadb, maestro, platform)
+        // 4. If disableAnimations:
+        //      val state = session.saveAnimationState()
+        //      session.disableAnimations()
+        //      return a wrapper that restores on close using session.restoreAnimationState(state)
+        TODO("Wire Dadb connection and Maestro initialization")
+    }
+
+    private suspend fun connectIos(
+        deviceId: String?,
+        disableAnimations: Boolean,
+    ): DeviceSession {
+        // 1. Discover or connect to iOS simulator/device
+        // 2. Install XCTest runner if needed
+        // 3. Create IOSDriver
+        // 4. Return IosDeviceSession(iosDriver)
+        TODO("Wire Maestro iOS driver initialization")
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/device/src/
+git commit -m "feat(device): add DeviceSessionFactory with auto-discovery and animation management"
+```
+
+---
+
+### Task 5: Unit tests for non-SDK logic
+
+The device layer has limited unit testability since most logic requires a real device. Focus tests on the tree converters and the shared logic that doesn't need SDK connections.
+
+**Files:**
+- Test: `verity/device/src/test/kotlin/me/chrisbanes/verity/device/DeviceSessionFactoryTest.kt`
+
+**Step 1: Write basic structure tests**
+
+```kotlin
+package me.chrisbanes.verity.device
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class DeviceSessionFactoryTest {
+    @Test
+    fun `animation state preserves values`() {
+        val state = DeviceSession.AnimationState("1.0", "1.0", "1.0")
+        assertThat(state.windowScale).isEqualTo("1.0")
+        assertThat(state.transitionScale).isEqualTo("1.0")
+        assertThat(state.animatorScale).isEqualTo("1.0")
+    }
+}
+```
+
+**Step 2: Run test**
+
+Run: `./gradlew :verity:device:test`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add verity/device/src/test/
+git commit -m "test(device): add basic DeviceSessionFactory tests"
+```
+
+---
+
+## Verification
+
+After all tasks, `:verity:device` should contain:
+
+```
+verity/device/src/main/kotlin/me/chrisbanes/verity/device/
+├── DeviceSession.kt
+├── DeviceSessionFactory.kt
+├── android/
+│   ├── AndroidDeviceSession.kt
+│   └── MaestroTreeConverter.kt
+└── ios/
+    ├── IosDeviceSession.kt
+    └── XcTestTreeConverter.kt
+```
+
+For the **scaffold milestone**, it is acceptable for SDK-interaction sections to remain stubbed temporarily.
+
+For the **production-ready milestone** (required before downstream phases depend on device behavior), all `TODO()` stubs in production code must be removed and both Android+iOS paths must be verified against real SDK APIs.
+
+**Definition of Done (production-ready):**
+- No `TODO()` in `verity/device/src/main/kotlin/**`.
+- `./gradlew :verity:device:test` passes.
+- At least one Android and one iOS smoke command path has been executed and documented.

--- a/docs/plans/2026-03-11-phase-3-agent.md
+++ b/docs/plans/2026-03-11-phase-3-agent.md
@@ -1,0 +1,728 @@
+# Phase 3: `:verity:agent` — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the LLM agent layer with flow generation, assertion evaluation, and the main orchestration engine.
+
+**Architecture:** Two isolated agents (**Navigator** and **Inspector**) and a segment-aware **Orchestrator**. The Navigator generates Maestro YAML using a tiered model strategy (suggesting Claude 4.5 Haiku, Gemini 3.0 Flash, or GPT-5 mini). The Inspector evaluates assertions using capable models (Claude Sonnet 4.6, Gemini 3.1 Pro, or GPT 5.4). The Orchestrator employs a **subagent pattern**, executing each journey segment in an isolated session to minimize context window usage and prevent context drift.
+
+**Tech Stack:** Koog (`ai.koog:koog-agents`, `ai.koog:prompt-executor-anthropic-client`), kotlinx.coroutines
+
+**Design doc:** `docs/plans/2026-03-11-verity-design.md`
+
+**Prerequisite:** Phase 0, Phase 1, and Phase 2 complete.
+
+**Important:** The Koog API for agent construction, prompt DSL, and image attachment should be verified against the Koog documentation at https://docs.koog.ai/.
+
+**Delivery mode (required):**
+- **Scaffold milestone:** Prompt construction, parsing, and orchestration logic may land with temporary `TODO()` in live LLM execution points.
+- **Production-ready milestone:** No `TODO()` remains in `:verity:agent` production sources. Koog calls are wired and exercised with a real API key in smoke validation.
+
+### Task 0: Koog API validation spike (must happen first)
+
+**Goal:** eliminate API uncertainty before implementing agents.
+
+**Steps:**
+1. Validate Koog agent construction APIs for model selection and executor wiring.
+2. Validate multimodal attachment pattern for screenshot-based evaluation.
+3. Confirm response extraction semantics (raw text vs structured object) for JSON parsing.
+4. Update snippets in Tasks 2–4 to match verified APIs before coding.
+
+---
+
+### Task 1: Models configuration
+
+**Files:**
+- Create: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Models.kt`
+
+**Step 1: Write the models config**
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+/**
+ * LLM model configuration.
+ *
+ * Suggested NAVIGATOR models (Cheap/Structured):
+ * - Anthropic: "claude-haiku-4-5" (Recommended)
+ * - Google: "gemini-3.0-flash"
+ * - OpenAI: "gpt-5-mini"
+ *
+ * Suggested INSPECTOR models (Capable/Vision):
+ * - Anthropic: "claude-sonnet-4-6" (Recommended)
+ * - Google: "gemini-3.1-pro"
+ * - OpenAI: "gpt-5.4"
+ */
+object Models {
+    const val NAVIGATOR = "claude-haiku-4-5"
+    const val INSPECTOR = "claude-sonnet-4-6"
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/agent/src/
+git commit -m "feat(agent): add Models configuration"
+```
+
+---
+
+### Task 2: NavigatorAgent
+
+Converts natural language action steps into Maestro YAML.
+
+**Files:**
+- Create: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/NavigatorAgent.kt`
+- Test: `verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/NavigatorAgentTest.kt`
+
+**Step 1: Write the test**
+
+Test the prompt construction (not the LLM call itself — that requires an API key).
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import me.chrisbanes.verity.core.model.Platform
+import kotlin.test.Test
+
+class NavigatorAgentTest {
+    @Test
+    fun `system prompt includes bundled Maestro basics`() {
+        val prompt = NavigatorAgent.buildSystemPrompt(
+            platform = Platform.ANDROID_TV,
+            bundledContext = "Maestro basics: appId header, waitForAnimationToEnd, extendedWaitUntil",
+            injectedContext = "",
+        )
+        assertThat(prompt).contains("Maestro basics")
+    }
+
+    @Test
+    fun `system prompt includes platform context for Android TV`() {
+        val prompt = NavigatorAgent.buildSystemPrompt(
+            platform = Platform.ANDROID_TV,
+            bundledContext = "Bundled context",
+            injectedContext = "",
+        )
+        assertThat(prompt).contains("Android TV")
+        assertThat(prompt).contains("D-pad")
+    }
+
+    @Test
+    fun `system prompt includes platform context for iOS`() {
+        val prompt = NavigatorAgent.buildSystemPrompt(
+            platform = Platform.IOS,
+            bundledContext = "Bundled context",
+            injectedContext = "",
+        )
+        assertThat(prompt).contains("iOS")
+    }
+
+    @Test
+    fun `system prompt appends injected context`() {
+        val injectedContext = "App uses custom navigation component"
+        val prompt = NavigatorAgent.buildSystemPrompt(
+            platform = Platform.ANDROID_TV,
+            bundledContext = "Bundled context",
+            injectedContext = injectedContext,
+        )
+        assertThat(prompt).contains("custom navigation component")
+    }
+
+    @Test
+    fun `user message formats actions as numbered list`() {
+        val actions = listOf("Launch the app", "Press D-pad down", "Press select")
+        val message = NavigatorAgent.buildUserMessage(actions, "com.example.app")
+        assertThat(message).contains("1. Launch the app")
+        assertThat(message).contains("2. Press D-pad down")
+        assertThat(message).contains("3. Press select")
+        assertThat(message).contains("com.example.app")
+    }
+
+    @Test
+    fun `strips markdown code fences from response`() {
+        val response = "```yaml\nappId: com.example\n---\n- pressKey: back\n```"
+        val cleaned = NavigatorAgent.cleanResponse(response)
+        assertThat(cleaned).doesNotContain("```")
+        assertThat(cleaned).contains("appId: com.example")
+    }
+
+    @Test
+    fun `passes through clean response unchanged`() {
+        val response = "appId: com.example\n---\n- pressKey: back"
+        assertThat(NavigatorAgent.cleanResponse(response)).contains("appId: com.example")
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:agent:test --tests "me.chrisbanes.verity.agent.NavigatorAgentTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import me.chrisbanes.verity.core.model.Platform
+
+/**
+ * Generates Maestro YAML flows from natural language action steps.
+ * Uses a cheap model (Haiku-class) since the task is structured generation.
+ */
+class NavigatorAgent(
+    private val agent: AIAgent,
+    private val bundledContext: String,
+) {
+
+    /**
+     * Generate Maestro YAML for the given actions.
+     *
+     * @param actions Natural language action instructions
+     * @param appId The app package/bundle ID
+     * @param platform Target platform
+     * @param injectedContext Optional app-specific context from --context-path or MCP get_context
+     * @return Generated Maestro YAML string
+     */
+    suspend fun generate(
+        actions: List<String>,
+        appId: String,
+        platform: Platform,
+        injectedContext: String = "",
+    ): String {
+        val systemPrompt = buildSystemPrompt(platform, bundledContext, injectedContext)
+        val userMessage = buildUserMessage(actions, appId)
+
+        // Koog agent call using injected dependency:
+        // - If Koog supports per-call system prompt override, set it here.
+        // - Otherwise inject an AIAgentFactory and create an agent with systemPrompt.
+        // val response = agent.run(userMessage)
+        // return cleanResponse(response)
+        TODO("Wire Koog agent call — verify AIAgent API against Koog docs")
+    }
+
+    companion object {
+        private val CODE_FENCE = Regex("```\\w*\\n?|```")
+
+        fun buildSystemPrompt(
+            platform: Platform,
+            bundledContext: String,
+            injectedContext: String,
+        ): String {
+            val platformInstructions = when (platform) {
+                Platform.ANDROID_TV -> """
+                    You are generating Maestro YAML for an Android TV app.
+                    Android TV uses D-pad navigation (Remote Dpad Up/Down/Left/Right/Center).
+                    Always add waitForAnimationToEnd after navigation actions.
+                    Use extendedWaitUntil for content that needs time to load.
+                """.trimIndent()
+
+                Platform.ANDROID_MOBILE -> """
+                    You are generating Maestro YAML for an Android mobile app.
+                    Use tap, swipe, scroll, and input commands.
+                    Always add waitForAnimationToEnd after navigation actions.
+                """.trimIndent()
+
+                Platform.IOS -> """
+                    You are generating Maestro YAML for an iOS app.
+                    Use tap, swipe, scroll, and input commands.
+                    Always add waitForAnimationToEnd after navigation actions.
+                """.trimIndent()
+            }
+
+            return buildString {
+                appendLine("Generate ONLY valid Maestro YAML. No explanation, no markdown code blocks, just raw YAML.")
+                appendLine("Start with `appId: <id>`, then `---`, then commands.")
+                appendLine("Do NOT include screenshots or assertions.")
+                appendLine()
+                appendLine("Bundled context (always present):")
+                appendLine(bundledContext)
+                appendLine()
+                appendLine(platformInstructions)
+                if (injectedContext.isNotBlank()) {
+                    appendLine()
+                    appendLine("Injected app-specific context (optional):")
+                    appendLine(injectedContext)
+                }
+            }.trim()
+        }
+
+        fun buildUserMessage(actions: List<String>, appId: String): String = buildString {
+            appendLine("App ID: $appId")
+            appendLine()
+            appendLine("Generate a Maestro YAML flow for these actions:")
+            actions.forEachIndexed { index, action ->
+                appendLine("${index + 1}. $action")
+            }
+        }.trim()
+
+        fun cleanResponse(response: String): String =
+            response.replace(CODE_FENCE, "").trim()
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:agent:test --tests "me.chrisbanes.verity.agent.NavigatorAgentTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/agent/src/
+git commit -m "feat(agent): add NavigatorAgent with platform-aware prompts"
+```
+
+---
+
+### Task 3: InspectorAgent
+
+Evaluates assertions against screen state using tree text or screenshots.
+
+**Files:**
+- Create: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/InspectorAgent.kt`
+- Test: `verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/InspectorAgentTest.kt`
+
+**Step 1: Write the test**
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isTrue
+import assertk.assertions.isFalse
+import me.chrisbanes.verity.core.model.InspectionVerdict
+import kotlin.test.Test
+
+class InspectorAgentTest {
+    @Test
+    fun `system prompt describes inspector role`() {
+        val prompt = InspectorAgent.SYSTEM_PROMPT
+        assertThat(prompt).contains("testing inspector")
+        assertThat(prompt).contains("JSON")
+    }
+
+    @Test
+    fun `tree user message includes hierarchy and assertion`() {
+        val message = InspectorAgent.buildTreeMessage("hierarchy text", "Home is visible")
+        assertThat(message).contains("hierarchy text")
+        assertThat(message).contains("Home is visible")
+    }
+
+    @Test
+    fun `visual user message includes assertion`() {
+        val message = InspectorAgent.buildVisualMessage("Backdrop image loads")
+        assertThat(message).contains("Backdrop image loads")
+    }
+
+    @Test
+    fun `parses valid JSON verdict`() {
+        val json = """{"passed": true, "reasoning": "Home text found"}"""
+        val verdict = InspectorAgent.parseVerdict(json)
+        assertThat(verdict.passed).isTrue()
+        assertThat(verdict.reasoning).contains("Home text found")
+    }
+
+    @Test
+    fun `parses JSON with code fences`() {
+        val json = "```json\n{\"passed\": false, \"reasoning\": \"not found\"}\n```"
+        val verdict = InspectorAgent.parseVerdict(json)
+        assertThat(verdict.passed).isFalse()
+    }
+
+    @Test
+    fun `parse failure returns failed verdict`() {
+        val verdict = InspectorAgent.parseVerdict("garbage response")
+        assertThat(verdict.passed).isFalse()
+        assertThat(verdict.reasoning).contains("parse error")
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:agent:test --tests "me.chrisbanes.verity.agent.InspectorAgentTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import me.chrisbanes.verity.core.model.InspectionVerdict
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/**
+ * Evaluates assertions against screen state.
+ * Uses a capable model (Sonnet-class) for accuracy.
+ * Supports both tree-based (text) and visual (screenshot) evaluation.
+ */
+class InspectorAgent(
+    private val treeAgent: AIAgent,
+    private val visualAgent: AIAgent,
+) {
+
+    /**
+     * Evaluate an assertion against the accessibility tree text.
+     */
+    suspend fun evaluateTree(hierarchy: String, assertion: String): InspectionVerdict {
+        val message = buildTreeMessage(hierarchy, assertion)
+        // val response = treeAgent.run(message)
+        // return parseVerdict(response)
+        TODO("Wire Koog agent call for tree evaluation")
+    }
+
+    /**
+     * Evaluate an assertion against a screenshot.
+     */
+    suspend fun evaluateVisual(screenshotFile: File, assertion: String): InspectionVerdict {
+        val message = buildVisualMessage(assertion)
+        // Use Koog image DSL: visualAgent.run { image(screenshotFile); text(message) }
+        // return parseVerdict(response)
+        TODO("Wire Koog agent call with vision for visual evaluation")
+    }
+
+    companion object {
+        private val lenientJson = Json { ignoreUnknownKeys = true; isLenient = true }
+        private val CODE_FENCE = Regex("```\\w*\\n?|```")
+
+        const val SYSTEM_PROMPT = """You are a visual testing inspector for a mobile/TV app.
+Evaluate whether a screenshot or accessibility tree matches an assertion.
+Respond with ONLY JSON: {"passed": true/false, "reasoning": "..."}
+Do not include any other text or explanation outside the JSON."""
+
+        fun buildTreeMessage(hierarchy: String, assertion: String): String = buildString {
+            appendLine("Accessibility tree:")
+            appendLine(hierarchy)
+            appendLine()
+            appendLine("Assertion to evaluate: $assertion")
+        }.trim()
+
+        fun buildVisualMessage(assertion: String): String =
+            "Evaluate the attached screenshot against this assertion: $assertion"
+
+        fun parseVerdict(response: String): InspectionVerdict {
+            val cleaned = response.replace(CODE_FENCE, "").trim()
+            return try {
+                lenientJson.decodeFromString(InspectionVerdict.serializer(), cleaned)
+            } catch (e: Exception) {
+                InspectionVerdict(
+                    passed = false,
+                    reasoning = "Inspector parse error: ${e.message}. Raw response: $cleaned",
+                )
+            }
+        }
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:agent:test --tests "me.chrisbanes.verity.agent.InspectorAgentTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/agent/src/
+git commit -m "feat(agent): add InspectorAgent with tree and visual evaluation"
+```
+
+---
+
+### Task 4: Orchestrator
+
+The main execution engine that runs journeys segment by segment.
+
+**Files:**
+- Create: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt`
+- Create: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/OrchestratorResult.kt`
+- Test: `verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt`
+
+**Step 1: Write the result types**
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import me.chrisbanes.verity.core.model.AssertMode
+
+data class SegmentResult(
+    val index: Int,
+    val passed: Boolean,
+    val assertionMode: AssertMode? = null,
+    val reasoning: String = "",
+)
+
+data class JourneyResult(
+    val journeyName: String,
+    val segments: List<SegmentResult>,
+) {
+    val passed: Boolean get() = segments.all { it.passed }
+    val failedAt: Int? get() = segments.firstOrNull { !it.passed }?.index
+}
+
+data class LoopResult(
+    val satisfied: Boolean,
+    val iterations: Int,
+    val reasoning: String = "",
+)
+```
+
+**Step 2: Write the test**
+
+Test the orchestrator's decision logic with a mock DeviceSession.
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import me.chrisbanes.verity.core.model.Platform
+import kotlin.test.Test
+
+class OrchestratorTest {
+    @Test
+    fun `classifies all-key-mapped actions as fast path`() {
+        val actions = listOf("press d-pad down", "press d-pad down", "press select")
+        val isFastPath = Orchestrator.isFastPath(actions, Platform.ANDROID_TV)
+        assertThat(isFastPath).isTrue()
+    }
+
+    @Test
+    fun `classifies non-mappable actions as slow path`() {
+        val actions = listOf("press d-pad down", "navigate to settings page")
+        val isFastPath = Orchestrator.isFastPath(actions, Platform.ANDROID_TV)
+        assertThat(isFastPath).isEqualTo(false)
+    }
+}
+```
+
+**Step 3: Run test to verify it fails**
+
+Run: `./gradlew :verity:agent:test --tests "me.chrisbanes.verity.agent.OrchestratorTest"`
+Expected: FAIL
+
+**Step 4: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import me.chrisbanes.verity.core.hierarchy.HierarchyFilter
+import me.chrisbanes.verity.core.keymap.PlatformKeyMapper
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Journey
+import me.chrisbanes.verity.core.model.JourneySegment
+import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.core.journey.JourneySegmenter
+import me.chrisbanes.verity.device.DeviceSession
+import java.io.File
+
+/**
+ * Runs journeys segment by segment using a subagent pattern.
+ * Each segment is isolated from previous ones to keep context windows small
+ * and prevent interference between unrelated steps.
+ */
+class Orchestrator(
+    private val session: DeviceSession,
+    private val navigatorFactory: () -> NavigatorAgent,
+    private val inspectorFactory: () -> InspectorAgent,
+    private val context: String = "",
+) {
+    suspend fun run(journey: Journey): JourneyResult {
+        val segments = JourneySegmenter.segment(journey.steps)
+        val results = mutableListOf<SegmentResult>()
+
+        for (segment in segments) {
+            // Create fresh subagents for this segment to ensure isolation
+            val navigator = navigatorFactory()
+            val inspector = inspectorFactory()
+
+            val result = executeSegment(segment, journey.app, journey.platform, navigator, inspector)
+            results.add(result)
+            if (!result.passed) break
+        }
+
+        return JourneyResult(journeyName = journey.name, segments = results)
+    }
+
+    private suspend fun executeSegment(
+        segment: JourneySegment,
+        appId: String,
+        platform: Platform,
+        navigator: NavigatorAgent,
+        inspector: InspectorAgent,
+    ): SegmentResult {
+        // Execute actions
+        if (segment.actions.isNotEmpty()) {
+            val instructions = segment.actions.map { it.instruction }
+            if (isFastPath(instructions, platform)) {
+                executeFastPath(instructions, platform)
+            } else {
+                executeSlowPath(instructions, appId, platform, navigator)
+            }
+        }
+
+        // Execute loop
+        segment.loop?.let { loop ->
+            val loopResult = executeLoop(loop.action, loop.until, loop.max, platform)
+            return SegmentResult(
+                index = segment.index,
+                passed = loopResult.satisfied,
+                reasoning = loopResult.reasoning,
+            )
+        }
+
+        // Evaluate assertion
+        segment.assertion?.let { assert ->
+            val verdict = evaluateAssertion(assert.description, assert.mode, inspector)
+            return SegmentResult(
+                index = segment.index,
+                passed = verdict,
+                assertionMode = assert.mode,
+                reasoning = "",
+            )
+        }
+
+        // Actions only, no assertion — always passes
+        return SegmentResult(index = segment.index, passed = true)
+    }
+
+    private suspend fun executeFastPath(instructions: List<String>, platform: Platform) {
+        val mapper = PlatformKeyMapper.forPlatform(platform)
+        for (instruction in instructions) {
+            val keyName = mapper.map(instruction)!!
+            session.pressKey(keyName)
+            session.waitForAnimationToEnd()
+        }
+    }
+
+    private suspend fun executeSlowPath(
+        instructions: List<String>,
+        appId: String,
+        platform: Platform,
+        navigator: NavigatorAgent,
+    ) {
+        val yaml = navigator.generate(instructions, appId, platform, context)
+        session.executeFlow(yaml)
+    }
+
+    private suspend fun executeLoop(
+        action: String,
+        until: String,
+        max: Int,
+        platform: Platform,
+    ): LoopResult {
+        val mapper = PlatformKeyMapper.forPlatform(platform)
+        val keyName = mapper.map(action)
+
+        for (i in 1..max) {
+            // Check exit condition (deterministic first)
+            if (session.containsText(until)) {
+                return LoopResult(satisfied = true, iterations = i, reasoning = "Text '$until' found")
+            }
+
+            // Execute action
+            if (keyName != null) {
+                session.pressKey(keyName)
+                session.waitForAnimationToEnd()
+            } else {
+                TODO("LLM fallback for non-key-mapped loop actions")
+            }
+        }
+
+        // Final check after max iterations
+        if (session.containsText(until)) {
+            return LoopResult(satisfied = true, iterations = max, reasoning = "Text '$until' found after max iterations")
+        }
+
+        return LoopResult(satisfied = false, iterations = max, reasoning = "Text '$until' not found after $max iterations")
+    }
+
+    private suspend fun evaluateAssertion(
+        description: String,
+        mode: AssertMode,
+        inspector: InspectorAgent,
+    ): Boolean {
+        return when (mode) {
+            AssertMode.VISIBLE -> session.containsText(description)
+            AssertMode.FOCUSED -> session.checkFocused(description)
+            AssertMode.TREE -> {
+                val hierarchy = session.captureHierarchy(HierarchyFilter.CONTENT)
+                inspector.evaluateTree(hierarchy, description).passed
+            }
+            AssertMode.VISUAL -> {
+                val tempFile = File.createTempFile("verity-screenshot-", ".png")
+                try {
+                    session.captureScreenshot(tempFile)
+                    inspector.evaluateVisual(tempFile, description).passed
+                } finally {
+                    tempFile.delete()
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun isFastPath(instructions: List<String>, platform: Platform): Boolean {
+            val mapper = PlatformKeyMapper.forPlatform(platform)
+            return mapper.allMappable(instructions)
+        }
+    }
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `./gradlew :verity:agent:test --tests "me.chrisbanes.verity.agent.OrchestratorTest"`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add verity/agent/src/
+git commit -m "feat(agent): add Orchestrator with fast-path key mapping and cost-aware assertions"
+```
+
+---
+
+### Task 5: Run all agent tests
+
+**Step 1: Run the full agent test suite**
+
+```bash
+./gradlew :verity:agent:test
+```
+
+Expected: ALL PASS
+
+---
+
+## Verification
+
+After all tasks, `:verity:agent` should contain:
+
+```
+verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/
+├── Models.kt
+├── NavigatorAgent.kt
+├── InspectorAgent.kt
+├── Orchestrator.kt
+└── OrchestratorResult.kt
+```
+
+For the **scaffold milestone**, temporary stubs at Koog call-sites are acceptable while API wiring is being validated.
+
+For the **production-ready milestone** (required before relying on autonomous execution), all Koog call-sites must be fully wired and no `TODO()` may remain in production code.
+
+**Definition of Done (production-ready):**
+- No `TODO()` in `verity/agent/src/main/kotlin/**`.
+- `./gradlew :verity:agent:test` passes.
+- Smoke run proves one tree assertion and one visual assertion path execute with live model calls.

--- a/docs/plans/2026-03-11-phase-4-mcp.md
+++ b/docs/plans/2026-03-11-phase-4-mcp.md
@@ -1,0 +1,648 @@
+# Phase 4: `:verity:mcp` — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the MCP server with 12 tools, session management, hierarchy snapshot store, and screenshot compression.
+
+**Architecture:** `VerityMcpServer` registers 12 tools using the MCP Kotlin SDK. `McpDeviceSessionManager` maintains a thread-safe registry of persistent device connections with per-session mutexes. `McpHierarchySnapshotStore` provides LRU snapshot storage for captured hierarchies. Two transport modes: stdio (default) and HTTP (Ktor/Netty).
+
+**Tech Stack:** MCP Kotlin SDK (`io.modelcontextprotocol:kotlin-sdk`), Ktor (Netty), kotlinx.serialization
+
+**Design doc:** `docs/plans/2026-03-11-verity-design.md`
+
+**Prerequisite:** Phase 0, Phase 1, and Phase 2 complete. For production rollout, Phase 3 should also be production-ready so LLM-backed paths can be validated end-to-end.
+
+**Important:** Verify the MCP Kotlin SDK API against https://modelcontextprotocol.github.io/kotlin-sdk/. The patterns below are based on the SDK's documented API.
+
+**Delivery mode (required):**
+- **Scaffold milestone:** Utility components and tool-registration structure can land first, even if some tool handlers/transports are temporarily stubbed.
+- **Production-ready milestone:** All 12 tools and both transports are fully wired. No `TODO()` remains in `:verity:mcp` production sources.
+
+### Task 0: MCP SDK validation spike (must happen first)
+
+**Goal:** confirm server/tool/transport APIs before implementation.
+
+**Steps:**
+1. Verify the MCP Kotlin SDK tool registration API (schema declaration, handler signature, return content types).
+2. Verify stdio transport wiring.
+3. Verify HTTP transport wiring with Ktor integration.
+4. Update Task 4 snippets to match validated API surfaces before coding.
+
+---
+
+### Task 1: McpHierarchySnapshotStore
+
+**Files:**
+- Create: `verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/McpHierarchySnapshotStore.kt`
+- Test: `verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/McpHierarchySnapshotStoreTest.kt`
+
+**Step 1: Write the tests**
+
+```kotlin
+package me.chrisbanes.verity.mcp
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import me.chrisbanes.verity.core.hierarchy.HierarchyNode
+import java.util.UUID
+import kotlin.test.Test
+
+class McpHierarchySnapshotStoreTest {
+    private val sessionId = UUID.randomUUID()
+    private val store = McpHierarchySnapshotStore()
+
+    private fun createNode(text: String) = HierarchyNode(id = UUID.randomUUID().toString(), text = text)
+
+    @Test
+    fun `add and retrieve snapshot`() {
+        val node = createNode("Home")
+        val id = store.add(sessionId, node)
+        val snapshot = store.get(sessionId, id)
+        assertThat(snapshot).isNotNull()
+        assertThat(snapshot?.text).isEqualTo("Home")
+    }
+
+    @Test
+    fun `get nonexistent snapshot returns null`() {
+        assertThat(store.get(sessionId, UUID.randomUUID())).isNull()
+    }
+
+    @Test
+    fun `latest returns most recent snapshot`() {
+        store.add(sessionId, createNode("first"))
+        store.add(sessionId, createNode("second"))
+        assertThat(store.latest(sessionId)?.text).isEqualTo("second")
+    }
+
+    @Test
+    fun `previous returns second-to-last snapshot`() {
+        store.add(sessionId, createNode("first"))
+        store.add(sessionId, createNode("second"))
+        assertThat(store.previous(sessionId)?.text).isEqualTo("first")
+    }
+
+    @Test
+    fun `evicts oldest when over capacity`() {
+        val smallStore = McpHierarchySnapshotStore(maxPerSession = 3)
+        val id1 = smallStore.add(sessionId, createNode("a"))
+        smallStore.add(sessionId, createNode("b"))
+        smallStore.add(sessionId, createNode("c"))
+        smallStore.add(sessionId, createNode("d")) // should evict "a" based on LRU
+        assertThat(smallStore.get(sessionId, id1)).isNull()
+    }
+
+    @Test
+    fun `sessions are isolated`() {
+        val session1 = UUID.randomUUID()
+        val session2 = UUID.randomUUID()
+        store.add(session1, createNode("session1 data"))
+        store.add(session2, createNode("session2 data"))
+        assertThat(store.latest(session1)?.text).isEqualTo("session1 data")
+        assertThat(store.latest(session2)?.text).isEqualTo("session2 data")
+    }
+
+    @Test
+    fun `clear removes all snapshots for session`() {
+        store.add(sessionId, createNode("data"))
+        store.clear(sessionId)
+        assertThat(store.latest(sessionId)).isNull()
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:mcp:test --tests "me.chrisbanes.verity.mcp.McpHierarchySnapshotStoreTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.mcp
+
+import me.chrisbanes.verity.core.hierarchy.HierarchyNode
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+class McpHierarchySnapshotStore(
+    private val maxPerSession: Int = 10,
+) {
+    private val sessions = ConcurrentHashMap<UUID, LinkedHashMap<UUID, HierarchyNode>>()
+
+    fun add(sessionId: UUID, hierarchy: HierarchyNode): UUID {
+        val snapshots = sessions.getOrPut(sessionId) {
+            // true flag enables access-order (LRU cache behavior)
+            object : LinkedHashMap<UUID, HierarchyNode>(maxPerSession, 0.75f, true) {
+                override fun removeEldestEntry(eldest: MutableMap.MutableEntry<UUID, HierarchyNode>?): Boolean =
+                    size > maxPerSession
+            }
+        }
+        val snapshotId = UUID.randomUUID()
+        synchronized(snapshots) {
+            snapshots[snapshotId] = hierarchy
+        }
+        return snapshotId
+    }
+
+    fun get(sessionId: UUID, snapshotId: UUID): HierarchyNode? =
+        sessions[sessionId]?.let { synchronized(it) { it[snapshotId] } }
+
+    fun latest(sessionId: UUID): HierarchyNode? =
+        sessions[sessionId]?.let { synchronized(it) { it.values.lastOrNull() } }
+
+    fun previous(sessionId: UUID): HierarchyNode? =
+        sessions[sessionId]?.let { synchronized(it) {
+            val values = it.values.toList()
+            if (values.size >= 2) values[values.size - 2] else null
+        }}
+
+    fun clear(sessionId: UUID) {
+        sessions.remove(sessionId)
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:mcp:test --tests "me.chrisbanes.verity.mcp.McpHierarchySnapshotStoreTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/mcp/src/
+git commit -m "feat(mcp): add McpHierarchySnapshotStore with LRU eviction"
+```
+
+---
+
+### Task 2: McpDeviceSessionManager
+
+**Files:**
+- Create: `verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/McpDeviceSessionManager.kt`
+- Test: `verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/McpDeviceSessionManagerTest.kt`
+
+**Step 1: Write the test**
+
+```kotlin
+package me.chrisbanes.verity.mcp
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class McpDeviceSessionManagerTest {
+    @Test
+    fun `session handle contains id and device info`() {
+        val handle = SessionHandle(
+            sessionId = java.util.UUID.randomUUID(),
+            deviceId = "emulator-5554",
+        )
+        assertThat(handle.deviceId).isEqualTo("emulator-5554")
+        assertThat(handle.sessionId).isNotNull()
+    }
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `./gradlew :verity:mcp:test --tests "me.chrisbanes.verity.mcp.McpDeviceSessionManagerTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.mcp
+
+import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.device.DeviceSession
+import me.chrisbanes.verity.device.DeviceSessionFactory
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+data class SessionHandle(
+    val sessionId: UUID,
+    val deviceId: String,
+)
+
+data class SessionEntry(
+    val deviceId: String,
+    val session: DeviceSession,
+    val mutex: Mutex = Mutex(),
+    var lastUsedAt: Long = System.currentTimeMillis(),
+    val savedAnimationScales: DeviceSessionFactory.AnimationState? = null,
+)
+
+class McpDeviceSessionManager {
+
+    private val sessions = ConcurrentHashMap<UUID, SessionEntry>()
+
+    suspend fun open(
+        platform: Platform,
+        deviceId: String? = null,
+        disableAnimations: Boolean = false,
+    ): SessionHandle {
+        val session = DeviceSessionFactory.connect(platform, deviceId, disableAnimations)
+        val id = UUID.randomUUID()
+
+        val animationState = if (disableAnimations && platform != Platform.IOS) {
+            val state = DeviceSessionFactory.saveAnimationScales(session)
+            DeviceSessionFactory.disableAnimations(session)
+            state
+        } else null
+
+        val resolvedDeviceId = deviceId ?: "auto-discovered"
+        sessions[id] = SessionEntry(
+            deviceId = resolvedDeviceId,
+            session = session,
+            savedAnimationScales = animationState,
+        )
+
+        return SessionHandle(sessionId = id, deviceId = resolvedDeviceId)
+    }
+
+    suspend fun <T> withSession(sessionId: UUID, block: suspend (DeviceSession) -> T): T {
+        val entry = sessions[sessionId]
+            ?: throw IllegalArgumentException("No session found with ID: $sessionId")
+        return entry.mutex.withLock {
+            entry.lastUsedAt = System.currentTimeMillis()
+            block(entry.session)
+        }
+    }
+
+    suspend fun close(sessionId: UUID) {
+        val entry = sessions.remove(sessionId)
+            ?: throw IllegalArgumentException("No session found with ID: $sessionId")
+        entry.mutex.withLock {
+            entry.savedAnimationScales?.let {
+                DeviceSessionFactory.restoreAnimations(entry.session, it)
+            }
+            entry.session.close()
+        }
+    }
+
+    fun isOpen(sessionId: UUID): Boolean = sessions.containsKey(sessionId)
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:mcp:test --tests "me.chrisbanes.verity.mcp.McpDeviceSessionManagerTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/mcp/src/
+git commit -m "feat(mcp): add McpDeviceSessionManager with mutex-guarded sessions"
+```
+
+---
+
+### Task 3: Screenshot compression utility
+
+**Files:**
+- Create: `verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/ScreenshotCompressor.kt`
+- Test: `verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/ScreenshotCompressorTest.kt`
+
+**Step 1: Write the test**
+
+```kotlin
+package me.chrisbanes.verity.mcp
+
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotEmpty
+import java.awt.image.BufferedImage
+import java.io.File
+import java.util.Base64
+import javax.imageio.ImageIO
+import kotlin.test.Test
+
+class ScreenshotCompressorTest {
+    @Test
+    fun `compresses and base64 encodes a PNG`() {
+        val tempPng = createTestPng(800, 600)
+        try {
+            val base64 = ScreenshotCompressor.compressToBase64(tempPng)
+            assertThat(base64).isNotEmpty()
+            // Should be valid base64
+            val decoded = Base64.getDecoder().decode(base64)
+            assertThat(decoded.size).isGreaterThan(0)
+        } finally {
+            tempPng.delete()
+        }
+    }
+
+    @Test
+    fun `scales down wide images`() {
+        val tempPng = createTestPng(2560, 1440)
+        try {
+            val base64 = ScreenshotCompressor.compressToBase64(tempPng, maxWidth = 1280)
+            val decoded = Base64.getDecoder().decode(base64)
+            // JPEG output should be smaller than the raw PNG
+            assertThat(decoded.size).isLessThan(tempPng.length().toInt())
+        } finally {
+            tempPng.delete()
+        }
+    }
+
+    @Test
+    fun `does not upscale small images`() {
+        val tempPng = createTestPng(640, 480)
+        try {
+            val base64 = ScreenshotCompressor.compressToBase64(tempPng, maxWidth = 1280)
+            assertThat(base64).isNotEmpty()
+        } finally {
+            tempPng.delete()
+        }
+    }
+
+    private fun createTestPng(width: Int, height: Int): File {
+        val img = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+        val g = img.createGraphics()
+        g.fillRect(0, 0, width, height)
+        g.dispose()
+        val file = File.createTempFile("test-screenshot-", ".png")
+        ImageIO.write(img, "PNG", file)
+        return file
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :verity:mcp:test --tests "me.chrisbanes.verity.mcp.ScreenshotCompressorTest"`
+Expected: FAIL
+
+**Step 3: Write the implementation**
+
+```kotlin
+package me.chrisbanes.verity.mcp
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.Base64
+import javax.imageio.IIOImage
+import javax.imageio.ImageIO
+import javax.imageio.ImageWriteParam
+
+object ScreenshotCompressor {
+
+    fun compressToBase64(
+        pngFile: File,
+        maxWidth: Int = 1280,
+        jpegQuality: Float = 0.75f,
+    ): String {
+        var image = ImageIO.read(pngFile)
+
+        // Scale down if wider than maxWidth
+        if (image.width > maxWidth) {
+            val scale = maxWidth.toDouble() / image.width
+            val newHeight = (image.height * scale).toInt()
+            val scaled = BufferedImage(maxWidth, newHeight, BufferedImage.TYPE_INT_RGB)
+            val g = scaled.createGraphics()
+            g.drawImage(image.getScaledInstance(maxWidth, newHeight, java.awt.Image.SCALE_SMOOTH), 0, 0, null)
+            g.dispose()
+            image = scaled
+        }
+
+        // Encode as JPEG
+        val baos = ByteArrayOutputStream()
+        val writer = ImageIO.getImageWritersByFormatName("jpeg").next()
+        val param = writer.defaultWriteParam.apply {
+            compressionMode = ImageWriteParam.MODE_EXPLICIT
+            compressionQuality = jpegQuality
+        }
+        writer.output = ImageIO.createImageOutputStream(baos)
+        writer.write(null, IIOImage(image, null, null), param)
+        writer.dispose()
+
+        return Base64.getEncoder().encodeToString(baos.toByteArray())
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :verity:mcp:test --tests "me.chrisbanes.verity.mcp.ScreenshotCompressorTest"`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add verity/mcp/src/
+git commit -m "feat(mcp): add ScreenshotCompressor for MCP transport"
+```
+
+---
+
+### Task 4: VerityMcpServer — tool registration
+
+This is the main server setup with all 12 tools.
+
+**Files:**
+- Create: `verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt`
+
+**Step 1: Write the server skeleton**
+
+```kotlin
+package me.chrisbanes.verity.mcp
+
+import me.chrisbanes.verity.core.context.ContextLoader
+import me.chrisbanes.verity.core.hierarchy.HierarchyFilter
+import me.chrisbanes.verity.core.journey.JourneyLoader
+import me.chrisbanes.verity.core.model.Platform
+import io.modelcontextprotocol.kotlin.sdk.Server
+import io.modelcontextprotocol.kotlin.sdk.ServerOptions
+import java.io.File
+import java.util.UUID
+
+/**
+ * Verity MCP server with 12 tools for device automation.
+ *
+ * NOTE: Verify the MCP Kotlin SDK tool registration API against
+ * https://modelcontextprotocol.github.io/kotlin-sdk/
+ * The patterns below follow the SDK's documented `server.addTool()` API.
+ */
+class VerityMcpServer(
+    private val sessionManager: McpDeviceSessionManager = McpDeviceSessionManager(),
+    private val snapshotStore: McpHierarchySnapshotStore = McpHierarchySnapshotStore(),
+    private val contextPath: File? = null,
+) {
+
+    fun create(): Server {
+        val server = Server(
+            ServerOptions(name = "verity", version = "0.1.0"),
+        )
+
+        registerOpenSession(server)
+        registerCloseSession(server)
+        registerListJourneys(server)
+        registerLoadJourney(server)
+        registerRunFlow(server)
+        registerPressKey(server)
+        registerCaptureScreenshot(server)
+        registerCaptureHierarchy(server)
+        registerCheckVisible(server)
+        registerCheckFocused(server)
+        registerRunLoop(server)
+        registerGetContext(server)
+
+        return server
+    }
+
+    // --- Tool Registrations ---
+    // Each tool follows this pattern:
+    //   server.addTool(name, description, inputSchema) { params ->
+    //       // implementation
+    //       TextContent("result")
+    //   }
+
+    private fun registerOpenSession(server: Server) {
+        // Params: platform? (string), device? (string), disable_animations? (boolean)
+        // Returns: session_id, device info
+        TODO("Register open_session tool — verify MCP SDK addTool API")
+    }
+
+    private fun registerCloseSession(server: Server) {
+        // Params: session_id (string, required)
+        // Returns: confirmation message
+        TODO("Register close_session tool")
+    }
+
+    private fun registerListJourneys(server: Server) {
+        // Params: path? (string)
+        // Returns: formatted list of journey files
+        TODO("Register list_journeys tool")
+    }
+
+    private fun registerLoadJourney(server: Server) {
+        // Params: path (string, required)
+        // Returns: parsed journey steps
+        TODO("Register load_journey tool")
+    }
+
+    private fun registerRunFlow(server: Server) {
+        // Params: session_id (string, required), yaml (string, required),
+        //         await_focus_change? (boolean)
+        // Returns: SUCCESS/FAILED + output
+        TODO("Register run_flow tool")
+    }
+
+    private fun registerPressKey(server: Server) {
+        // Params: session_id (string, required), key (string, required)
+        // Returns: confirmation
+        TODO("Register press_key tool")
+    }
+
+    private fun registerCaptureScreenshot(server: Server) {
+        // Params: session_id (string, required), save_to_file? (string)
+        // Returns: base64 JPEG (ImageContent) or file path
+        TODO("Register capture_screenshot tool")
+    }
+
+    private fun registerCaptureHierarchy(server: Server) {
+        // Params: session_id (string, required), filter? (string: focus/content/all)
+        // Returns: hierarchy text + snapshot_id
+        TODO("Register capture_hierarchy tool")
+    }
+
+    private fun registerCheckVisible(server: Server) {
+        // Params: session_id (string, required), text (string, required)
+        // Returns: true/false (case-insensitive deterministic substring match)
+        TODO("Register check_visible tool")
+    }
+
+    private fun registerCheckFocused(server: Server) {
+        // Params: session_id (string, required), text (string, required)
+        // Returns: true/false
+        TODO("Register check_focused tool")
+    }
+
+    private fun registerRunLoop(server: Server) {
+        // Params: session_id (string, required), action (string, required),
+        //         until (string, required), max? (int), wait_ms? (int)
+        // Returns: SATISFIED/NOT SATISFIED + iteration count
+        TODO("Register run_loop tool")
+    }
+
+    private fun registerGetContext(server: Server) {
+        // Params: path? (string)
+        // Returns: bundled default context + optional path-based injected context
+        TODO("Register get_context tool")
+    }
+
+    // --- Transport ---
+
+    /**
+     * Start in stdio mode (reads from stdin, writes to stdout).
+     * Used by Claude Code and other IDE integrations.
+     */
+    suspend fun startStdio() {
+        val server = create()
+        // server.connectStdio()
+        TODO("Wire MCP SDK stdio transport")
+    }
+
+    /**
+     * Start in HTTP mode using Ktor/Netty.
+     * Used for remote or multi-client scenarios.
+     */
+    suspend fun startHttp(host: String = "0.0.0.0", port: Int = 8080) {
+        val server = create()
+        // Ktor server setup with mcpStreamableHttp
+        TODO("Wire MCP SDK HTTP transport via Ktor")
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/mcp/src/
+git commit -m "feat(mcp): add VerityMcpServer skeleton with 12 tool registrations"
+```
+
+---
+
+### Task 5: Run all MCP tests
+
+**Step 1: Run the full MCP test suite**
+
+```bash
+./gradlew :verity:mcp:test
+```
+
+Expected: ALL PASS
+
+---
+
+## Verification
+
+After all tasks, `:verity:mcp` should contain:
+
+```
+verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/
+├── VerityMcpServer.kt
+├── McpDeviceSessionManager.kt
+├── McpHierarchySnapshotStore.kt
+└── ScreenshotCompressor.kt
+```
+
+For the **scaffold milestone**, utility components and server structure may land before all tool handlers are fully wired.
+
+For the **production-ready milestone** (required before Skills and integration smoke depend on MCP behavior), all 12 tools and both transports must be implemented with no production stubs.
+
+**Definition of Done (production-ready):**
+- No `TODO()` in `verity/mcp/src/main/kotlin/**`.
+- `./gradlew :verity:mcp:test` passes.
+- `open_session`, `check_visible`, `capture_hierarchy`, and `close_session` are validated in both stdio and HTTP transport smoke checks.

--- a/docs/plans/2026-03-11-phase-5-cli.md
+++ b/docs/plans/2026-03-11-phase-5-cli.md
@@ -1,0 +1,338 @@
+# Phase 5: `:verity:cli` — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the CLI entry point with three subcommands: `run`, `list`, and `mcp`.
+
+**Architecture:** Thin Clikt commands that wire the agent and MCP modules together. `Verity` is the root command with shared options (device, platform, api-key). Each subcommand delegates to the appropriate module.
+
+**Tech Stack:** Clikt (`com.github.ajalt.clikt:clikt`)
+
+**Design doc:** `docs/plans/2026-03-11-verity-design.md`
+
+**Prerequisite:** Phase 0 through Phase 4 complete.
+
+---
+
+### Task 1: Root command with shared options
+
+**Files:**
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/Verity.kt`
+
+**Step 1: Write the root command**
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.enum
+import me.chrisbanes.verity.core.model.Platform
+
+class Verity : CliktCommand(
+    name = "verity",
+    help = "LLM-powered E2E testing for mobile and TV",
+) {
+    val device: String? by option("--device", help = "Device ID or IP:port (auto-discover if omitted)")
+    val platform: Platform by option("--platform", help = "Target platform")
+        .enum<Platform>()
+        .default(Platform.ANDROID_TV)
+    val apiKey: String? by option("--api-key", envvar = "ANTHROPIC_API_KEY", help = "LLM API key")
+    val contextPath: String? by option(
+        "--context-path",
+        help = "Optional path to additional context markdown files",
+    )
+    val noAnimations: Boolean by option("--no-animations", help = "Disable device animations")
+        .flag(default = false)
+
+    override fun run() = Unit // Root command just holds shared options
+}
+
+fun main(args: Array<String>) = Verity()
+    .subcommands(RunCommand(), ListCommand(), McpCommand())
+    .main(args)
+```
+
+**Note:** The `.flag()` method is Clikt's way to define boolean flags. Verify exact Clikt 5.x API — the flag syntax may differ slightly.
+
+**Step 2: Commit**
+
+```bash
+git add verity/cli/src/
+git commit -m "feat(cli): add Verity root command with shared options"
+```
+
+---
+
+### Task 2: RunCommand
+
+**Files:**
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+
+**Step 1: Write the command**
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.optional
+import me.chrisbanes.verity.agent.NavigatorAgent
+import me.chrisbanes.verity.agent.InspectorAgent
+import me.chrisbanes.verity.agent.Orchestrator
+import me.chrisbanes.verity.core.context.ContextLoader
+import me.chrisbanes.verity.core.journey.JourneyLoader
+import me.chrisbanes.verity.device.DeviceSessionFactory
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+class RunCommand : CliktCommand(
+    name = "run",
+    help = "Execute a journey file against a connected device",
+) {
+    private val journeyPath by argument("journey", help = "Path to .journey.yaml file").optional()
+
+    override fun run() = runBlocking {
+        val parent = currentContext.parent?.command as Verity
+
+        val apiKey = parent.apiKey
+            ?: error("API key required. Set ANTHROPIC_API_KEY or use --api-key")
+
+        // Load journey
+        val file = journeyPath?.let { File(it) }
+            ?: error("Journey path required. Use: verity run <path.journey.yaml>")
+
+        require(file.exists()) { "Journey file not found: $file" }
+
+        val journey = JourneyLoader.fromFile(file)
+        echo("Running journey: ${journey.name}")
+        echo("App: ${journey.app}")
+        echo("Platform: ${journey.platform}")
+
+        // Connect to device
+        val session = DeviceSessionFactory.connect(
+            platform = parent.platform,
+            deviceId = parent.device,
+            disableAnimations = parent.noAnimations,
+        )
+
+        session.use {
+            // Load optional injected context.
+            // NavigatorAgent always includes bundled Maestro/platform context internally.
+            val injectedContext = parent.contextPath?.let { ContextLoader.load(File(it)) } ?: ""
+
+            // Create agents and orchestrator
+            val orchestrator = Orchestrator(
+                session = session,
+                navigatorFactory = { NavigatorAgent(apiKey) },
+                inspectorFactory = { InspectorAgent(apiKey) },
+                context = injectedContext,
+            )
+
+            // Run
+            val result = orchestrator.run(journey)
+
+            // Report
+            echo()
+            if (result.passed) {
+                echo("PASSED: All ${result.segments.size} segments passed")
+            } else {
+                echo("FAILED: Segment ${result.failedAt} failed")
+                result.segments.filter { !it.passed }.forEach { seg ->
+                    echo("  Segment ${seg.index}: ${seg.reasoning}")
+                }
+            }
+        }
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/cli/src/
+git commit -m "feat(cli): add RunCommand for autonomous journey execution"
+```
+
+---
+
+### Task 3: ListCommand
+
+**Files:**
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/ListCommand.kt`
+
+**Step 1: Write the command**
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import me.chrisbanes.verity.core.journey.JourneyLoader
+import java.io.File
+
+class ListCommand : CliktCommand(
+    name = "list",
+    help = "List available journey files",
+) {
+    private val path by option("--path", help = "Directory to search for journeys")
+        .default(".")
+
+    override fun run() {
+        val dir = File(path)
+        require(dir.isDirectory) { "Not a directory: $path" }
+
+        val journeys = JourneyLoader.listJourneyFiles(dir)
+        if (journeys.isEmpty()) {
+            echo("No journey files found in $path")
+            return
+        }
+
+        echo("Found ${journeys.size} journey(s):")
+        journeys.forEach { file ->
+            val journey = JourneyLoader.fromFile(file)
+            echo("  ${file.name} — ${journey.name} (${journey.platform})")
+        }
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/cli/src/
+git commit -m "feat(cli): add ListCommand for journey discovery"
+```
+
+---
+
+### Task 4: McpCommand
+
+**Files:**
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/McpCommand.kt`
+
+**Step 1: Write the command**
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import me.chrisbanes.verity.mcp.VerityMcpServer
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+class McpCommand : CliktCommand(
+    name = "mcp",
+    help = "Start the MCP server for interactive device control",
+) {
+    private val transport by option("--transport", help = "Transport mode: stdio or http")
+        .default("stdio")
+    private val port by option("--port", help = "HTTP port (only for http transport)")
+        .int()
+        .default(8080)
+    private val host by option("--host", help = "HTTP host (only for http transport)")
+        .default("0.0.0.0")
+
+    override fun run() = runBlocking {
+        val parent = currentContext.parent?.command as Verity
+        val contextDir = parent.contextPath?.let { File(it) }
+
+        val server = VerityMcpServer(contextPath = contextDir)
+
+        when (transport) {
+            "stdio" -> {
+                echo("Starting Verity MCP server (stdio)...")
+                server.startStdio()
+            }
+            "http" -> {
+                echo("Starting Verity MCP server on $host:$port...")
+                server.startHttp(host, port)
+            }
+            else -> error("Unknown transport: $transport. Use 'stdio' or 'http'.")
+        }
+    }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/cli/src/
+git commit -m "feat(cli): add McpCommand for MCP server startup"
+```
+
+---
+
+### Task 5: CLI smoke test
+
+**Files:**
+- Test: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityTest.kt`
+
+**Step 1: Write the test**
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import assertk.assertThat
+import assertk.assertions.contains
+import com.github.ajalt.clikt.testing.test
+import kotlin.test.Test
+
+class VerityTest {
+    @Test
+    fun `prints help message`() {
+        val result = Verity()
+            .subcommands(RunCommand(), ListCommand(), McpCommand())
+            .test("--help")
+        assertThat(result.output).contains("verity")
+        assertThat(result.output).contains("run")
+        assertThat(result.output).contains("list")
+        assertThat(result.output).contains("mcp")
+    }
+
+    @Test
+    fun `list command shows help`() {
+        val result = Verity()
+            .subcommands(RunCommand(), ListCommand(), McpCommand())
+            .test("list --help")
+        assertThat(result.output).contains("journey")
+    }
+}
+```
+
+**Note:** Clikt's `test()` extension runs the command with captured output — verify this API against Clikt 5.x docs. The import may be `com.github.ajalt.clikt.testing.test`.
+
+**Step 2: Run tests**
+
+Run: `./gradlew :verity:cli:test`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add verity/cli/src/test/
+git commit -m "test(cli): add CLI smoke tests"
+```
+
+---
+
+## Verification
+
+After all tasks, `:verity:cli` should contain:
+
+```
+verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/
+├── Verity.kt        # Root command + main()
+├── RunCommand.kt    # verity run
+├── ListCommand.kt   # verity list
+└── McpCommand.kt    # verity mcp
+```
+
+Run `./gradlew :verity:cli:run --args="--help"` to verify the CLI prints its help output.

--- a/docs/plans/2026-03-11-phase-6-skills.md
+++ b/docs/plans/2026-03-11-phase-6-skills.md
@@ -1,0 +1,505 @@
+# Phase 6: Skills — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Write the markdown skill files and shared context documents that teach an AI agent how to use Verity's MCP tools.
+
+**Architecture:** Skills are pure markdown — no code, no Gradle module. They encode workflow knowledge as structured instructions. A shared procedures document contains prerequisites and common patterns. Context files describe the target app, platform controls, and Maestro commands.
+
+**Design doc:** `docs/plans/2026-03-11-verity-design.md`
+
+**Prerequisite:** Phase 0 through Phase 5 complete. For production usage, Phase 4 (`:verity:mcp`) must be **production-ready** (no tool/transport stubs), not just scaffolded.
+
+---
+
+### Task 1: Shared context — procedures.md
+
+**Files:**
+- Modify: `verity/skills/context/procedures.md`
+
+**Step 1: Write the shared procedures**
+
+```markdown
+# Verity Shared Procedures
+
+## Prerequisites
+
+Before running any skill:
+
+1. **Device precheck**: Run `adb devices` (Android) or `xcrun simctl list` (iOS) to confirm a device is connected.
+2. **Open session**: Call `open_session` with appropriate `platform` and `disable_animations: true`. Store the returned `session_id`.
+3. **Optional context injection**: Call `get_context` when app-specific details are needed. Verity already bundles default Maestro and platform guidance, so this step is additive.
+
+## Flow Generation
+
+Generate Maestro YAML using bundled defaults, plus optional injected context from `get_context` when available. Follow these rules:
+
+- Start with `appId: <id>`, then `---`, then commands
+- Add `waitForAnimationToEnd` after navigation actions
+- Use `extendedWaitUntil` for content that needs time to load
+- Do NOT include screenshots or assertions in flows
+
+**Before generating**: If the flow depends on current focus position, call `capture_hierarchy` with `filter: focus` first. Never infer focus from screenshots.
+
+## Step Classification
+
+Classify each action step as:
+
+- **Static**: Deterministic key press (e.g., "Press D-pad down", "Press select", "Press back"). Batch consecutive static steps into a single `run_flow`.
+- **Loop**: Requires navigating through dynamic content (e.g., "Navigate down until TV Shows row"). Use the loop execution procedure.
+
+## Loop Execution (Overshoot-and-Correct)
+
+Instead of pressing one key at a time:
+
+1. **Inspect First**: Call `capture_hierarchy` to understand the current view and identify the size of one viewport (e.g., number of items currently visible).
+2. **Overshoot**: Generate a flow that navigates by roughly 1 full viewport (e.g., if 4 items are visible, press Down 4 times).
+3. **Inspect**: Call `capture_hierarchy` again to evaluate the `until` condition.
+4. **Correct**: If overshot, generate a correction flow based on the captured state.
+
+Goal: Viewport-aware navigation + 1 inspection + at most 1 correction. Minimizes tool calls.
+
+Alternative: Use `run_loop` tool for simple loops where single key presses are sufficient.
+
+## Assertion Evaluation
+
+Choose tool by assertion type:
+
+| Type | Tool | Cost |
+|------|------|------|
+| `[?visible]` | `check_visible` | Free — deterministic case-insensitive substring match |
+| `[?focused]` | `check_focused` | Free — deterministic focus detection |
+| `[?tree]` | `capture_hierarchy` + LLM evaluation | Medium — you evaluate the tree text |
+| `[?]` (inferred) | Depends on inferred mode | Varies |
+| `[?visual]` | `capture_screenshot` + LLM vision evaluation | High — screenshot + analysis |
+
+**Optimization**: Reuse recent hierarchy captures. If no navigation occurred since the last `capture_hierarchy`, skip re-capture.
+
+## Session Cleanup
+
+Always call `close_session` when done. This restores animation scales if they were disabled.
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/skills/context/procedures.md
+git commit -m "feat(skills): write shared procedures document"
+```
+
+---
+
+### Task 2: Shared context — tv-controls.md
+
+**Files:**
+- Modify: `verity/skills/context/tv-controls.md` (create if only placeholder exists)
+
+**Step 1: Write the TV controls reference**
+
+Create `verity/skills/context/tv-controls.md`:
+```markdown
+# TV Remote Controls
+
+## Android TV D-pad Mapping
+
+| Action | Maestro Key Name |
+|--------|-----------------|
+| D-pad Up | `Remote Dpad Up` |
+| D-pad Down | `Remote Dpad Down` |
+| D-pad Left | `Remote Dpad Left` |
+| D-pad Right | `Remote Dpad Right` |
+| Select / Enter | `Remote Dpad Center` |
+| Back | `back` |
+| Home | `home` |
+| Menu | `Remote Media Menu` |
+| Play/Pause | `Remote Media Play Pause` |
+| Rewind | `Remote Media Rewind` |
+| Fast Forward | `Remote Media Fast Forward` |
+
+## Maestro YAML for Key Presses
+
+```yaml
+- pressKey: Remote Dpad Down
+- pressKey: Remote Dpad Center
+- pressKey: back
+```
+
+## Navigation Patterns
+
+- **Row navigation**: D-pad Left/Right moves between items in a row
+- **Vertical navigation**: D-pad Up/Down moves between rows
+- **Content entry**: Select (D-pad Center) opens detail pages
+- **Back navigation**: Back returns to previous screen
+
+Always add `waitForAnimationToEnd` after navigation presses to allow transitions to complete.
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/skills/context/tv-controls.md
+git commit -m "feat(skills): write TV remote controls reference"
+```
+
+---
+
+### Task 3: Shared context — maestro.md
+
+**Files:**
+- Create: `verity/skills/context/maestro.md`
+
+**Step 1: Write the Maestro command reference**
+
+```markdown
+# Maestro YAML Reference
+
+## Flow Structure
+
+Every flow starts with an `appId` header:
+
+```yaml
+appId: com.example.app
+---
+- pressKey: Remote Dpad Down
+- waitForAnimationToEnd
+```
+
+## Common Commands
+
+### Key Presses
+```yaml
+- pressKey: Remote Dpad Down
+- pressKey: back
+```
+
+### Wait for Animation
+```yaml
+- waitForAnimationToEnd
+```
+Always add after navigation actions.
+
+### Extended Wait
+```yaml
+- extendedWaitUntil:
+    visible: "Loading"
+    timeout: 10000
+```
+Use when content needs time to load.
+
+### Launch App
+```yaml
+- launchApp:
+    appId: com.example.app
+    clearState: false
+```
+
+### Tap (Mobile/Tablet)
+```yaml
+- tapOn:
+    text: "Button Label"
+```
+
+### Scroll (Mobile/Tablet)
+```yaml
+- scroll
+```
+
+### Input Text
+```yaml
+- inputText: "search query"
+```
+
+### Assert Visible (in flows)
+```yaml
+- assertVisible:
+    text: "Expected Text"
+```
+
+Note: For Verity journeys, prefer using `[?]` assertions in the journey file rather than Maestro's built-in assertions. Journey assertions are evaluated by the orchestrator with LLM support.
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/skills/context/maestro.md
+git commit -m "feat(skills): write Maestro YAML command reference"
+```
+
+---
+
+### Task 4: Shared context — app.md placeholder
+
+**Files:**
+- Create: `verity/skills/context/app.md`
+
+**Step 1: Write the placeholder**
+
+This file is app-specific — it gets filled in per project.
+
+```markdown
+# App Context
+
+This file describes the target application. Update it with:
+
+- App package/bundle ID
+- Screen descriptions and navigation structure
+- Key UI patterns (content rows, detail pages, settings)
+- Known quirks or accessibility issues
+
+## Example
+
+```
+App ID: com.example.launcher
+Platform: Android TV
+
+Screens:
+- Home: Spotlight carousel at top, content rows below (Movies, TV Shows, etc.)
+- Detail: Backdrop image, title, synopsis, tabs (Episodes, Cast, Trailers)
+- Settings: Vertical list of options
+
+Navigation:
+- D-pad Down from spotlight reaches first content row
+- D-pad Right/Left moves between items in a row
+- Select on an item opens its detail page
+- Back returns to Home
+```
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/skills/context/app.md
+git commit -m "feat(skills): add app context placeholder"
+```
+
+---
+
+### Task 5: Skill — verity-run
+
+**Files:**
+- Modify: `verity/skills/run/SKILL.md`
+
+**Step 1: Write the skill**
+
+```markdown
+# Verity Run
+
+Non-interactive journey execution against a connected device.
+
+## Prerequisites
+
+Follow the shared prerequisites from `procedures.md`:
+1. Device precheck (adb devices / xcrun simctl list)
+2. Open session with `open_session(platform, disable_animations: true)`
+3. Optionally load app-specific context with `get_context` (defaults are already bundled)
+
+## Workflow
+
+### 1. Resolve Journey
+
+If the user provided a path:
+- Call `load_journey(path)` to parse it
+
+If no path provided:
+- Call `list_journeys` to show available journeys
+- Ask the user to pick one
+- Call `load_journey` with the selected path
+
+### 2. Announce Plan
+
+Show the journey details:
+- Name, app ID, platform
+- Number of segments
+- Assertion type breakdown (count of VISIBLE, FOCUSED, TREE, VISUAL)
+
+Ask: "Ready to execute? [yes/no]"
+
+### 3. Execute Segments
+
+For each segment:
+
+**Actions:**
+- Classify each action as static or loop (see procedures.md)
+- Batch consecutive static actions across segments when possible into a single `run_flow`
+- Execute loops via overshoot-and-correct or `run_loop`
+
+**Assertions:**
+- `[?visible]` → call `check_visible(session_id, text)`. Report: "check_visible('text') → true/false"
+- `[?focused]` → call `check_focused(session_id, text)`. Report: "check_focused('text') → true/false"
+- `[?tree]` → call `capture_hierarchy(session_id)`, then evaluate the hierarchy text against the assertion. Explain your reasoning.
+- `[?visual]` → call `capture_screenshot(session_id)`, then evaluate the screenshot against the assertion. Explain your reasoning.
+
+**Optimization**: Reuse recent hierarchy if no navigation occurred since last capture.
+
+**On failure**: Show which segment failed and why. Ask: "Continue to next segment or stop? [continue/stop]"
+
+### 4. Final Report
+
+After all segments complete (or after stopping), present:
+
+**Results table:**
+
+| Seg | Steps | Assertion | Type | Result | Notes |
+|-----|-------|-----------|------|--------|-------|
+| 0 | Launch app | Home | VISIBLE | PASS | check_visible found 'Home' |
+| 1 | Press down x3 | TV Shows row | VISIBLE | PASS | |
+| ... | ... | ... | ... | ... | ... |
+
+**Summary**: 3-5 sentence narrative covering what was tested, what passed/failed, and any notable observations.
+
+### 5. Cleanup
+
+Call `close_session(session_id)`.
+
+## Performance Tips
+
+- Batch static steps across consecutive segments into one `run_flow`
+- Prefer `check_visible` and `check_focused` (free) over `capture_hierarchy` + LLM
+- Prefer `capture_hierarchy(filter: focus)` over full `capture_hierarchy` when only checking focus
+- Skip re-capturing hierarchy if no navigation occurred since last capture
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/skills/run/SKILL.md
+git commit -m "feat(skills): write verity-run skill"
+```
+
+---
+
+### Task 6: Skill — verity-author
+
+**Files:**
+- Modify: `verity/skills/author/SKILL.md`
+
+**Step 1: Write the skill**
+
+```markdown
+# Verity Author
+
+Collaboratively create a new journey file by exploring a live device.
+
+## Prerequisites
+
+Follow the shared prerequisites from `procedures.md`:
+1. Device precheck
+2. Open session with `open_session(platform, disable_animations: true)`
+3. Optionally load app-specific context with `get_context` (defaults are already bundled)
+
+## Workflow
+
+### 1. Resolve Journey Name
+
+Ask the user for a journey name. The file will be saved as:
+`verity/journeys/<name>.journey.yaml`
+
+### 2. Resolve App ID
+
+If the context specifies an app ID, confirm it. Otherwise ask the user.
+
+### 3. Opening Snapshot
+
+- Call `capture_screenshot(session_id)` — show the screenshot
+- Call `capture_hierarchy(session_id)` — describe what's visible
+- Ask: "Is this the right starting point? [yes/no]"
+
+### 4. Get Journey Goal
+
+Ask: "What should this journey test? (one sentence)"
+
+Use this as the journey `name` field.
+
+### 5. Step Authoring Loop
+
+Repeat until the user says "finish":
+
+#### Suggest Next Step
+
+Based on the current screen state (screenshot + hierarchy):
+- Suggest a plain-English step (e.g., "Press D-pad down to navigate to Movies row")
+- Show the suggestion and ask: "Accept, edit, or skip?"
+
+#### Ask About Assertions
+
+After each navigation action, suggest an assertion:
+- Prefer the cheapest type that works:
+  - If the expected text is short and specific → suggest `[?] Text` (will infer VISIBLE)
+  - If the check requires understanding structure → suggest `[?tree] description`
+  - Only suggest `[?visual]` if the check involves images, colors, or visual layout
+- Ask: "Add this assertion? [yes/edit/skip]"
+
+#### What Next?
+
+Ask: "What would you like to do?"
+- **Describe an action** — user types a step, you generate and execute it
+- **Add a loop** — user describes what to navigate to, you create a loop step
+- **Take a screenshot** — capture current state for reference
+- **Finish** — done authoring
+
+### 6. Review
+
+Show the complete journey YAML:
+
+```yaml
+name: <journey goal>
+app: <app id>
+platform: <platform>
+
+steps:
+  - <step 1>
+  - <step 2>
+  - ...
+```
+
+Ask: "Any edits? [looks good/edit]"
+
+If editing, apply changes and show updated YAML.
+
+### 7. Save
+
+Write the journey file to `verity/journeys/<name>.journey.yaml`.
+
+### 8. Next Steps
+
+Offer: "Journey saved! You can run it with `/verity-run <path>` or step through it with `/verity-debug <path>` (when available)."
+
+## Assertion Cost Awareness
+
+Always suggest the cheapest assertion mode that would work:
+
+1. **VISIBLE** (`[?] short text`): For checking specific text exists on screen. Free.
+2. **FOCUSED** (`[?focused] text`): For checking what's currently focused. Free.
+3. **TREE** (`[?tree] description`): For checking structure, relationships, or content meaning. Uses LLM.
+4. **VISUAL** (`[?visual] description`): For checking images, colors, layout. Uses LLM + vision. Last resort.
+
+When in doubt, default to VISIBLE for short checks and TREE for complex ones.
+```
+
+**Step 2: Commit**
+
+```bash
+git add verity/skills/author/SKILL.md
+git commit -m "feat(skills): write verity-author skill"
+```
+
+---
+
+## Verification
+
+After all tasks, the skills directory should contain:
+
+```
+verity/skills/
+├── context/
+│   ├── procedures.md    # Shared prerequisites and procedures
+│   ├── app.md           # App-specific context (placeholder)
+│   ├── tv-controls.md   # TV remote control reference
+│   └── maestro.md       # Maestro YAML command reference
+├── run/
+│   └── SKILL.md         # Non-interactive journey execution
+└── author/
+    └── SKILL.md         # Interactive journey authoring
+```
+
+No code to test — skills are pure markdown consumed by AI agents.

--- a/docs/plans/2026-03-11-phase-7-integration-smoke.md
+++ b/docs/plans/2026-03-11-phase-7-integration-smoke.md
@@ -1,0 +1,118 @@
+# Phase 7: Integration Smoke — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Validate that CLI, agent, device, and MCP layers work together through a minimal end-to-end smoke suite.
+
+**Architecture:** Keep smoke coverage thin and high-signal. Use one fake/mock-backed path for deterministic CI and one real-device/manual path for confidence in SDK wiring.
+
+**Design doc:** `docs/plans/2026-03-11-verity-design.md`
+
+**Prerequisite:** Phase 0 through Phase 6 complete. Phase 2, Phase 3, and Phase 4 must be production-ready (no production `TODO()` stubs).
+
+---
+
+### Task 1: Add smoke fixtures
+
+**Files:**
+- Create: `verity/cli/src/test/resources/smoke/minimal.journey.yaml`
+- Create: `verity/cli/src/test/resources/smoke/context/app.md`
+
+**Step 1: Add a minimal journey**
+
+Use a tiny journey with one action and one assertion, for example:
+
+```yaml
+name: Minimal smoke
+app: com.example.app
+platform: android-tv
+steps:
+  - Press d-pad down
+  - [?visible] Home
+```
+
+**Step 2: Add minimal context**
+
+Add simple app context text used by smoke tests.
+
+---
+
+### Task 2: CLI run smoke (test-double backed)
+
+**Files:**
+- Create: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt`
+
+**Step 1: Add test**
+
+Validate `verity run` can load journey, segment it, execute through test doubles, and emit pass/fail output.
+
+**Step 2: Run test**
+
+```bash
+./gradlew :verity:cli:test --tests "me.chrisbanes.verity.cli.RunCommandSmokeTest"
+```
+
+Expected: PASS
+
+---
+
+### Task 3: MCP smoke (stdio + HTTP)
+
+**Files:**
+- Create: `verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/VerityMcpServerSmokeTest.kt`
+
+**Step 1: Add tests**
+
+Use a test-double session manager to validate, at minimum:
+- `open_session`
+- `check_visible` (case-insensitive behavior)
+- `capture_hierarchy`
+- `close_session`
+
+Run once via stdio wiring and once via HTTP wiring.
+
+**Step 2: Run test**
+
+```bash
+./gradlew :verity:mcp:test --tests "me.chrisbanes.verity.mcp.VerityMcpServerSmokeTest"
+```
+
+Expected: PASS
+
+---
+
+### Task 4: Manual real-device smoke checklist
+
+**Files:**
+- Update: `README.md` (or existing runbook section) with a short manual smoke checklist
+
+**Step 1: Add checklist**
+
+Document a minimal manual path:
+1. Start MCP server (`verity mcp --transport stdio` or `http`)
+2. Open session on a connected device
+3. Run one key press / one flow
+4. Run one visible check and one hierarchy capture
+5. Close session and verify cleanup
+
+---
+
+### Task 5: Full smoke gate
+
+**Step 1: Run the smoke targets together**
+
+```bash
+./gradlew :verity:mcp:test :verity:cli:test
+```
+
+Expected: ALL PASS
+
+---
+
+## Verification
+
+Integration smoke is complete when:
+- CLI smoke test passes.
+- MCP smoke tests pass for both stdio and HTTP transport.
+- `check_visible` behavior is verified as case-insensitive.
+- Manual real-device smoke checklist is documented and has been executed at least once.

--- a/docs/plans/2026-03-11-verity-design.md
+++ b/docs/plans/2026-03-11-verity-design.md
@@ -1,0 +1,530 @@
+# Verity: LLM-Powered E2E Testing for Mobile and TV
+
+## What Verity Is
+
+Verity is a Kotlin/JVM tool that combines device automation (Maestro SDK) with LLM reasoning (via Koog) to run end-to-end journey tests on Android TV, Android mobile, and iOS devices. It operates in two modes:
+
+1. **CLI mode** (`verity run`) — Executes journey YAML files against a connected device, using LLMs to generate Maestro flows and evaluate assertions.
+2. **MCP server mode** (`verity mcp`) — Exposes device control as MCP tools so an AI agent can interactively drive the device.
+
+LLMs serve two purposes: flow generation (turning English into Maestro YAML) and assertion evaluation (judging whether screen state matches an expectation). Deterministic fast-paths handle both when possible, so LLM calls happen only when necessary.
+
+---
+
+## Architecture
+
+```
+:verity:core  <── :verity:device  <── :verity:agent  <── :verity:cli
+                        ^                                      |
+                   :verity:mcp  <──────────────────────────────┘
+```
+
+### Module Responsibilities
+
+| Module | Depends on | Purpose |
+|--------|-----------|---------|
+| `:verity:core` | nothing (kotlinx.serialization, Kaml) | Models, journey format, step parsing, segmenter, key mapper, hierarchy renderer, assertion mode inferrer |
+| `:verity:device` | `:verity:core` | `DeviceSession` interface and platform-specific implementations (Android via Dadb + Maestro gRPC, iOS via Maestro XCTest HTTP) |
+| `:verity:agent` | `:verity:core`, `:verity:device` | Koog LLM setup, NavigatorAgent, InspectorAgent, Orchestrator |
+| `:verity:mcp` | `:verity:core`, `:verity:device` | MCP server (stdio + HTTP), 12 tools, session manager, snapshot store |
+| `:verity:cli` | `:verity:agent`, `:verity:mcp` | Clikt commands: `run`, `list`, `mcp` |
+
+**Key rule:** `:verity:mcp` does not depend on `:verity:agent`. The MCP server exposes raw device capabilities — the external AI agent provides the intelligence.
+
+### Project Structure
+
+```
+verity/
+├── build.gradle.kts
+├── settings.gradle.kts
+│
+└── verity/
+    ├── build.gradle.kts          # Shared config for submodules
+    ├── core/
+    │   └── src/main/kotlin/
+    │       ├── model/            # Journey, JourneyStep, AssertMode, VerityResult
+    │       ├── journey/          # JourneyLoader, JourneySegmenter
+    │       ├── parser/           # JourneyStepSerializer, inferrers
+    │       ├── keymap/           # PlatformKeyMapper interface + implementations
+    │       ├── hierarchy/        # HierarchyRenderer, HierarchyFilter
+    │       └── context/          # ContextLoader
+    │
+    ├── device/
+    │   └── src/main/kotlin/
+    │       ├── DeviceSession.kt
+    │       ├── DeviceSessionFactory.kt
+    │       ├── android/          # AndroidDeviceSession (Dadb + Maestro gRPC)
+    │       └── ios/              # IosDeviceSession (Maestro XCTest HTTP)
+    │
+    ├── agent/
+    │   └── src/main/kotlin/
+    │       ├── Models.kt
+    │       ├── NavigatorAgent.kt
+    │       ├── InspectorAgent.kt
+    │       └── Orchestrator.kt
+    │
+    ├── cli/
+    │   └── src/main/kotlin/
+    │       ├── Verity.kt         # Clikt root command
+    │       ├── RunCommand.kt
+    │       ├── ListCommand.kt
+    │       └── McpCommand.kt
+    │
+    ├── mcp/
+    │   └── src/main/kotlin/
+    │       ├── VerityMcpServer.kt
+    │       ├── McpDeviceSessionManager.kt
+    │       └── McpHierarchySnapshotStore.kt
+    │
+    └── skills/                   # Not a Gradle module — markdown only
+        ├── context/
+        │   ├── procedures.md
+        │   ├── app.md
+        │   ├── tv-controls.md
+        │   └── maestro.md
+        ├── run/
+        │   └── SKILL.md
+        └── author/
+            └── SKILL.md
+```
+
+---
+
+## Technology Stack
+
+| Component | Library | Purpose |
+|-----------|---------|---------|
+| CLI | Clikt | Argument parsing, subcommands |
+| YAML | Kaml | Journey deserialization with custom serializers |
+| Serialization | kotlinx.serialization | JSON/YAML encoding/decoding |
+| LLM | Koog (JetBrains) | Prompt DSL, model abstraction, provider-agnostic |
+| Android device | Dadb | ADB over TCP — persistent shared connection |
+| Android automation | Maestro SDK (embedded) | gRPC driver, UI automation, hierarchy capture |
+| iOS automation | Maestro XCTest client | HTTP client to on-device XCTest server (port 22087) |
+| MCP server | MCP Kotlin SDK | Tool registration, stdio/HTTP transport |
+| HTTP server | Ktor (Netty) | HTTP transport for MCP |
+| gRPC | grpc-netty-shaded | Bundled Netty to avoid version conflicts with Ktor |
+
+### Netty Conflict Resolution
+
+Maestro SDK uses gRPC with Netty 4.1; Ktor uses Netty 4.2. Resolved by:
+- Excluding `grpc-netty` globally
+- Using `grpc-netty-shaded` (bundles relocated Netty classes)
+- Pinning `io.grpc` artifacts to a single version
+
+---
+
+## Journey Format
+
+Journeys are YAML files describing user flows. File extension: `*.journey.yaml`.
+
+```yaml
+name: Browse home and open detail
+app: com.example.launcher
+platform: android-tv
+
+steps:
+  - Launch the app
+  - [?] Home
+  - Navigate down until TV Shows row
+  - Press select
+  - [?] Detail page shows title
+  - [?visual] Backdrop image loads
+  - [?focused] Settings menu item
+  - [?tree] Synopsis contains at least 2 sentences
+```
+
+### Assertion Syntax
+
+| Syntax | Meaning |
+|--------|---------|
+| `[?] text` | Assert with mode inferred by heuristics |
+| `[?visible] text` | Deterministic substring match (free) |
+| `[?focused] text` | Lenient focus detection (free) |
+| `[?tree] text` | Accessibility tree + LLM evaluation |
+| `[?visual] text` | Screenshot + LLM vision evaluation |
+
+### Step Parsing Chain
+
+Steps are parsed through a 5-stage priority chain:
+
+1. **`[?mode]` prefix** — `[?visual]`, `[?tree]`, `[?visible]`, `[?focused]` locks the assertion mode
+2. **`[?]` prefix** — Assert with mode chosen by `AssertModeInferrer`
+3. **Loop inference** — NL pattern: `<verb> ... until <condition>`
+4. **Assertion inference** — NL keywords: "Verify...", "Ensure...", "Confirm...", "Check..."
+5. **Default** — Action
+
+### Assert Mode Inference
+
+The `AssertModeInferrer` selects the cheapest sufficient mode:
+- Contains visual keywords (color, highlight, image, icon, animation, gradient, blur) → `VISUAL`
+- 3 words or fewer, no visual keywords → `VISIBLE`
+- Everything else → `TREE`
+
+### Loop Inference
+
+The `LoopStepInferrer` matches patterns like `<verb> ... until <condition> [up to N times]`:
+- Leading verb must be: press, navigate, move, scroll, go, step
+- The action part is normalized to platform key names
+
+---
+
+## Data Model
+
+```kotlin
+data class Journey(
+    val name: String,
+    val app: String,
+    val platform: Platform,
+    val steps: List<JourneyStep>
+)
+
+sealed interface JourneyStep {
+    data class Action(val instruction: String) : JourneyStep
+    data class Assert(val description: String, val mode: AssertMode) : JourneyStep
+    data class Loop(val action: String, val until: String, val max: Int = 20) : JourneyStep
+}
+
+enum class AssertMode { VISIBLE, FOCUSED, TREE, VISUAL }
+
+enum class Platform { ANDROID_TV, ANDROID_MOBILE, IOS }
+
+data class JourneySegment(
+    val index: Int,
+    val actions: List<JourneyStep.Action>,
+    val assertion: JourneyStep.Assert? = null,
+    val loop: JourneyStep.Loop? = null
+)
+```
+
+### Segmentation
+
+`JourneySegmenter` splits steps into independently executable segments:
+- Actions accumulate until an assertion → segment with those actions + assertion
+- Loops flush pending actions as a separate segment, then become their own segment
+- Trailing actions without an assertion become a final segment
+
+Each segment is a natural checkpoint: run actions, evaluate assertion, stop on failure.
+
+---
+
+## Device Layer
+
+### Interface
+
+```kotlin
+interface DeviceSession : AutoCloseable {
+    val platform: Platform
+
+    suspend fun executeFlow(yaml: String): FlowResult
+    suspend fun pressKey(keyName: String)
+    suspend fun captureHierarchy(filter: HierarchyFilter = CONTENT): String
+    suspend fun captureScreenshot(outputFile: File)
+    suspend fun containsText(text: String, ignoreCase: Boolean = true): Boolean
+    suspend fun checkFocused(text: String): Boolean
+    suspend fun shell(command: String): String
+    suspend fun waitForAnimationToEnd()
+}
+```
+
+### Implementations
+
+**`AndroidDeviceSession`**: Connects via Dadb (ADB over TCP). Creates a Maestro instance with persistent gRPC connection. Supports device ID, IP:port, or auto-discovery.
+
+**`IosDeviceSession`**: Installs XCTest runner on device/simulator. Communicates via HTTP to the on-device XCTest server (localhost:22087). Simulator management via `xcrun simctl`, physical devices via `devicectl`.
+
+### Factory
+
+```kotlin
+object DeviceSessionFactory {
+    suspend fun connect(
+        platform: Platform,
+        deviceId: String? = null,
+        disableAnimations: Boolean = false
+    ): DeviceSession
+}
+```
+
+Auto-discovers the device if no ID is given. Saves animation scales on connect, restores on close.
+
+### Hierarchy Rendering
+
+The accessibility tree renders to indented text with configurable attribute filtering:
+
+```
+[text=Home, resource-id=nav_home] (focused,clickable)
+  [text=Movies]
+  [text=TV Shows]
+  [text=Settings]
+```
+
+| Filter | Allowed keys | Use case |
+|--------|-------------|----------|
+| `FOCUS` | text, resource-id, selected | Navigation assertions |
+| `CONTENT` | text, accessibilityText, resource-id, bounds | Content verification (default) |
+| `ALL` | everything (minus empty/defaults) | Debugging |
+
+Empty strings, false booleans, and `enabled=true` are stripped. Empty container nodes with one or fewer children are collapsed.
+
+### Focus Detection
+
+Android TV (and sometimes iOS) places `focused=true` on container nodes while text lives in siblings or children. The lenient focus algorithm returns true if:
+- A focused node contains the text
+- A descendant of a focused node contains the text
+- A sibling of a focused node contains the text
+- An ancestor of a text node is focused
+
+### Platform Key Mapper
+
+`PlatformKeyMapper` maps natural language to platform key codes. Per-platform implementations, all in `:verity:core` (string-to-string mapping, no device SDK dependency):
+
+| Platform | Example mapping |
+|----------|----------------|
+| Android TV | "press d-pad down" → "Remote Dpad Down" |
+| Android Mobile | "press back" → "back" |
+| iOS | "press home" → home gesture mapping |
+
+When all actions in a segment map to known keys, the orchestrator bypasses LLM flow generation and presses keys directly.
+
+---
+
+## Agent Layer
+
+### LLM Configuration
+
+Verity uses a tiered model strategy via Koog. While Claude models are the recommended default for their strong reasoning and XML/YAML compliance, the system is provider-agnostic.
+
+| Tier | Task | Suggested Models |
+|------|------|------------------|
+| **Navigator** (Cheap) | YAML generation | `claude-haiku-4-5`, `gemini-3.0-flash`, `gpt-5-mini` |
+| **Inspector** (Capable) | Assertion evaluation | `claude-sonnet-4-6`, `gemini-3.1-pro`, `gpt-5.4` |
+
+Configured through Koog — can swap providers by updating the executor and model ID.
+
+### NavigatorAgent
+
+Converts natural language actions to Maestro YAML. Receives the target `Platform` and adjusts output accordingly (D-pad commands for TV, tap/swipe for mobile, iOS gestures for iOS).
+
+System prompt instructs: generate only valid Maestro YAML, no explanation, add `waitForAnimationToEnd` after navigation, use `extendedWaitUntil` for content that needs loading time.
+
+### InspectorAgent
+
+Evaluates assertions against screen state:
+- `evaluateTree(hierarchy, assertion)` — text-only, Sonnet-class model
+- `evaluateVisual(screenshot, assertion)` — vision-enabled, Sonnet-class model
+
+Returns `InspectionVerdict(passed: Boolean, reasoning: String)`. Lenient JSON parsing with code fence stripping.
+
+### Orchestrator
+
+Runs journeys segment by segment using a **subagent pattern** to keep context windows small and focused. Each segment is treated as a discrete task for a fresh agent instance, preventing the accumulation of history from unrelated segments.
+
+**Action execution (two paths):**
+- Fast path: all actions map via `PlatformKeyMapper` → direct `pressKey()` calls
+- Slow path: `NavigatorAgent` generates Maestro YAML → `executeFlow()`
+
+**Assertion evaluation (four modes):**
+
+| Mode | Method | Cost |
+|------|--------|------|
+| VISIBLE | `containsText()` — substring match | Free |
+| FOCUSED | `checkFocused()` — lenient tree walk | Free |
+| TREE | `InspectorAgent.evaluateTree()` | Medium |
+| VISUAL | `InspectorAgent.evaluateVisual()` | High |
+
+**Context Optimization:** By isolating each segment's reasoning into sequential subagent calls, Verity supports extremely long journeys that would otherwise exceed model context limits or cause "context drift" where early steps confuse later reasoning.
+
+---
+
+## MCP Server
+
+### Transport
+
+- **stdio** (default) — for Claude Code / IDE integration
+- **HTTP** — Ktor/Netty on configurable host:port
+
+### Session Manager
+
+Thread-safe registry of persistent device connections:
+
+```
+sessions: Map<UUID, SessionEntry>
+SessionEntry = { platform, DeviceSession, Mutex, lastUsedAt, savedAnimationScales }
+```
+
+Per-session mutex for safe concurrent tool calls. Animation scales saved on open, restored on close.
+
+### Snapshot Store
+
+LRU map of captured `HierarchyNode` trees (capped at 10 per session). Supports future diff functionality without refactoring.
+
+### Screenshot Compression
+
+For MCP transport: read PNG, scale to max 1280px width (bilinear interpolation), encode as JPEG at 0.75 quality, return as base64.
+
+### Tool Catalog (12 tools)
+
+| Tool | Required params | Returns | Notes |
+|------|----------------|---------|-------|
+| `open_session` | — | session_id, device info | Optional: platform, device, disable_animations |
+| `close_session` | session_id | confirmation | Restores animations if disabled |
+| `list_journeys` | — | formatted list | Optional: path |
+| `load_journey` | path | parsed steps | |
+| `run_flow` | session_id, yaml | SUCCESS/FAILED + output | Optional: await_focus_change |
+| `press_key` | session_id, key | confirmation | Optional focus change result |
+| `capture_screenshot` | session_id | base64 JPEG or file path | Optional: save_to_file |
+| `capture_hierarchy` | session_id | hierarchy text + snapshot_id | Optional: filter (focus/content/all) |
+| `check_visible` | session_id, text | true/false | Deterministic, case-insensitive |
+| `check_focused` | session_id, text | true/false | Lenient ancestor/sibling/child check |
+| `run_loop` | session_id, action, until | SATISFIED/NOT + iterations | Optional: max, wait_ms |
+| `get_context` | — | bundled defaults + markdown context text | Optional: path |
+
+---
+
+## CLI
+
+### Commands
+
+```
+verity run <journey>           Execute a journey autonomously
+verity list [--path <dir>]     List available journey files
+verity mcp [--transport <t>]   Start MCP server (stdio or http)
+```
+
+### Shared Options
+
+```
+--device <id>            Device ID or IP:port (auto-discover if omitted)
+--platform <platform>    android-tv | android | ios (default: android-tv)
+--no-animations          Disable device animations during run
+--api-key <key>          LLM API key (or ANTHROPIC_API_KEY env var)
+--context-path <dir>     Optional path to additional context markdown files
+```
+
+---
+
+## Skills
+
+### Shared Procedures (context/procedures.md)
+
+1. **Prerequisites** — device precheck, `open_session` with platform + disable_animations, optionally `get_context` for app-specific details
+2. **Flow generation** — agent generates Maestro YAML from bundled Maestro/platform defaults plus optional injected context; calls `capture_hierarchy` first if current state matters
+3. **Step classification** — static (key presses, batchable into one `run_flow`) vs. loop (overshoot-and-correct)
+4. **Assertion evaluation** — `check_visible`/`check_focused` (free) before `capture_hierarchy` + LLM reasoning before `capture_screenshot` + LLM vision
+5. **Cleanup** — always `close_session`
+
+### verity-run
+
+Non-interactive journey execution:
+1. Resolve journey (path argument or pick from `list_journeys`)
+2. Announce plan — name, app, platform, segment count, assertion breakdown; confirm
+3. Execute segments — classify steps, batch static actions, overshoot-and-correct for loops, evaluate assertions
+4. On failure — show error, ask to continue or stop
+5. Final report — markdown table + narrative summary
+
+### verity-author
+
+Interactive journey creation from a live device:
+1. Open session, screenshot + hierarchy, confirm starting point
+2. Get journey name, app ID, goal
+3. Step loop — suggest next step from screen state, suggest cheapest assertion mode, ask what's next
+4. Review complete YAML, allow edits
+5. Write file, offer to run with verity-run
+
+### Deferred Skills
+
+- **verity-debug**: Step-through with screenshots and confirmation at each step
+- **verity-audit**: Content quality crawling with subagents
+
+Both can be added without modifying any Gradle module.
+
+---
+
+## Execution Data Flow
+
+### CLI Run
+
+```
+Journey YAML
+    │
+    ▼
+JourneyLoader.load() ──→ Journey(name, app, platform, steps)
+    │
+    ▼
+JourneySegmenter.segment() ──→ List<JourneySegment>
+    │
+    ▼
+Orchestrator.run() loops over segments:
+    │
+    ├── Actions present?
+    │   ├── All map to keys? → direct pressKey() calls
+    │   └── Otherwise → NavigatorAgent → executeFlow()
+    │
+    ├── Assertion present?
+    │   ├── VISIBLE → containsText()
+    │   ├── FOCUSED → checkFocused()
+    │   ├── TREE → captureHierarchy() → InspectorAgent.evaluateTree()
+    │   └── VISUAL → captureScreenshot() → InspectorAgent.evaluateVisual()
+    │
+    ├── Loop present?
+    │   └── checkCondition → pressKey/executeFlow → repeat
+    │
+    └── Failed? → stop, skip remaining segments
+```
+
+### MCP Server
+
+```
+AI Agent (Claude Code / Cursor / etc.)
+    │
+    ▼
+MCP Protocol (stdio or HTTP)
+    │
+    ▼
+VerityMcpServer
+    ├── open_session → DeviceSessionFactory.connect()
+    ├── press_key → session.pressKey()
+    ├── run_flow → session.executeFlow()
+    ├── capture_screenshot → session.captureScreenshot() → compress → base64
+    ├── capture_hierarchy → session.captureHierarchy() → snapshot store
+    ├── check_visible → session.containsText()
+    ├── check_focused → session.checkFocused()
+    ├── run_loop → pressKey() loop with condition check
+    └── close_session → restore animations → session.close()
+```
+
+---
+
+## Design Principles
+
+1. **Cost-aware assertions**: Free deterministic checks before cheap text LLM before expensive vision LLM. The `AssertModeInferrer` and `[?]` syntax make the cheapest mode the default path.
+
+2. **Fast-path key mapping**: Direct key presses for navigation bypass LLM flow generation entirely. Covers the most common actions (D-pad navigation on TV, basic gestures on mobile).
+
+3. **Persistent connections**: Embedded Maestro SDK with persistent gRPC (Android) and HTTP (iOS) connections. No process spawning per operation.
+
+4. **Segment-based execution**: Splitting at assertion boundaries creates natural checkpoints. Each segment is independent — clear failure attribution, debuggable output.
+
+5. **Subagent isolation**: Each segment is executed by an isolated agent session. This drastically reduces context window usage and eliminates the risk of "history hallucination" where the model conflates different parts of a long journey.
+
+6. **Platform abstraction**: One `DeviceSession` interface, platform-specific implementations. Core logic (parsing, segmentation, key mapping) is platform-aware but SDK-free.
+
+7. **Dual mode from one core**: The same device and core layers serve both autonomous CLI execution and interactive MCP-driven workflows. Author interactively, run in CI.
+
+---
+
+## Deliberate Omissions
+
+Features considered but excluded to keep the design lean:
+
+| Omission | Rationale |
+|----------|-----------|
+| LLM-based assertion mode planner | Deterministic inference is sufficient; adding an LLM call to decide whether to use an LLM adds cost without clear benefit |
+| Assertion mode selection policy | Only needed alongside an LLM planner |
+| Visual assertion budget tracking | Unnecessary complexity — journey authors can pin modes explicitly |
+| `diff_hierarchy` MCP tool | Nice-to-have; not needed by the run or author skills |
+| Separate `save_screenshot` tool | Merged into `capture_screenshot` with a `save_to_file` param |
+| Separate `capture_focused_tree` tool | Merged into `capture_hierarchy` with `filter=focus` param |
+| Explicit loop block syntax in YAML | NL inference handles loops cleanly |
+| verity-debug skill | Deferred — add once run and author are stable |
+| verity-audit skill | Deferred — add once run and author are stable |


### PR DESCRIPTION
## Summary
- Adds comprehensive design document covering architecture, journey format, device layer, agent layer, MCP server, CLI, and skills
- Adds 8 phased implementation plans (Phase 0–7) from Gradle scaffolding through integration smoke testing
- Updates LLM model references to current generations (Claude 4.5 Haiku / Sonnet 4.6, Gemini 3.0 Flash / 3.1 Pro, GPT-5 mini / 5.4)

## Test plan
- [ ] Review design doc for architectural accuracy
- [ ] Review phase plans for completeness and ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)