### PR TITLE
fix: retry flaky iOS XCTest driver connection in smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,6 @@ jobs:
           shutdown_after_job: true
 
       - name: iOS smoke tests
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: "300000"
         run: ./gradlew :verity:smoke-tests:test -Pinclude.tags=ios

--- a/verity/smoke-tests/src/test/kotlin/me/chrisbanes/verity/smoke/DeviceLifecycle.kt
+++ b/verity/smoke-tests/src/test/kotlin/me/chrisbanes/verity/smoke/DeviceLifecycle.kt
@@ -1,6 +1,7 @@
 package me.chrisbanes.verity.smoke
 
 import java.io.File
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
@@ -27,11 +28,25 @@ class DeviceLifecycle private constructor(
   private val simulatorUdid: String?,
 ) : AutoCloseable {
 
-  suspend fun connect(): DeviceSession = DeviceSessionFactory.connect(
-    platform = platform,
-    deviceId = simulatorUdid,
-    disableAnimations = false,
-  )
+  suspend fun connect(retries: Int = 2): DeviceSession {
+    var lastException: Exception? = null
+    repeat(retries) { attempt ->
+      try {
+        return DeviceSessionFactory.connect(
+          platform = platform,
+          deviceId = simulatorUdid,
+          disableAnimations = false,
+        )
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
+        lastException = e
+        System.err.println("Device connect attempt ${attempt + 1}/$retries failed: ${e.message}")
+        if (attempt < retries - 1) delay(5.seconds)
+      }
+    }
+    throw lastException!!
+  }
 
   override fun close() {
     if (!bootedByUs) return


### PR DESCRIPTION
## Summary
- Add retry logic (2 attempts) to `DeviceLifecycle.connect()` for transient XCTest driver timeouts
- Increase `MAESTRO_DRIVER_STARTUP_TIMEOUT` to 5 minutes in CI (up from default 2 min)

## Context
The iOS smoke test fails non-deterministically on GitHub Actions with `IOSDriverTimeoutException` — the Maestro XCTest runner sometimes takes longer than 2 minutes to bind on port 22087 after installation. The same setup passes on some runs and fails on others with no code changes.

## Test plan
- [x] `./gradlew check` passes locally
- [ ] CI `smoke-ios` job passes (or at least gets past the connection phase)