### PR TITLE
fix: guard retry count and scope retries to iOS in smoke tests

### DIFF
--- a/verity/smoke-tests/src/test/kotlin/me/chrisbanes/verity/smoke/DeviceLifecycle.kt
+++ b/verity/smoke-tests/src/test/kotlin/me/chrisbanes/verity/smoke/DeviceLifecycle.kt
@@ -28,7 +28,8 @@ class DeviceLifecycle private constructor(
   private val simulatorUdid: String?,
 ) : AutoCloseable {
 
-  suspend fun connect(retries: Int = 2): DeviceSession {
+  suspend fun connect(retries: Int = if (platform == Platform.IOS) 2 else 1): DeviceSession {
+    require(retries >= 1) { "retries must be at least 1, but was $retries" }
     var lastException: Exception? = null
     repeat(retries) { attempt ->
       try {


### PR DESCRIPTION
## Summary

- Add `require(retries >= 1)` to `DeviceLifecycle.connect()` to prevent an NPE when `retries` is 0 (the `repeat(0)` loop would skip, then `throw lastException!!` would crash)
- Change the default retry count to be platform-aware: iOS gets 2 retries (targeting flaky XCTest driver connections), non-iOS gets 1 (no retry) since those failures are typically deterministic

## Context

Addresses Copilot review feedback on PR #26.