### PR TITLE
Fix: Various Code Review Issues

### DIFF
--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/InspectorAgent.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/InspectorAgent.kt
@@ -2,8 +2,10 @@ package me.chrisbanes.verity.agent
 
 import ai.koog.agents.core.agent.AIAgent
 import java.nio.file.Path
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import me.chrisbanes.verity.core.model.InspectionVerdict
 
@@ -28,7 +30,9 @@ class InspectorAgent(
     val message = buildTreeMessage(hierarchy, assertion)
     val agent = treeAgentFactory()
     return try {
-      val response = agent.run(message)
+      val response = withTimeout(TREE_TIMEOUT) {
+        agent.run(message)
+      }
       parseVerdict(response)
     } finally {
       withContext(NonCancellable) { agent.close() }
@@ -49,6 +53,13 @@ class InspectorAgent(
       ignoreUnknownKeys = true
       isLenient = true
     }
+
+    /** Timeout for tree-based evaluation (text-only, should be fast). */
+    private val TREE_TIMEOUT = 30.seconds
+
+    /** Maximum length of raw response included in error messages to prevent oversized output. */
+    private const val MAX_RAW_RESPONSE_LENGTH = 500
+
     const val SYSTEM_PROMPT =
       "You are a visual testing inspector for a mobile/TV app.\n" +
         "Evaluate whether a screenshot or accessibility tree matches an assertion.\n" +
@@ -69,9 +80,14 @@ class InspectorAgent(
       return try {
         lenientJson.decodeFromString(InspectionVerdict.serializer(), cleaned)
       } catch (e: Exception) {
+        val truncated = if (cleaned.length > MAX_RAW_RESPONSE_LENGTH) {
+          cleaned.take(MAX_RAW_RESPONSE_LENGTH) + "... [truncated ${cleaned.length - MAX_RAW_RESPONSE_LENGTH} chars]"
+        } else {
+          cleaned
+        }
         InspectionVerdict(
           passed = false,
-          reasoning = "Inspector parse error: ${e.message}. Raw response: $cleaned",
+          reasoning = "Inspector parse error: ${e.message}. Raw response: $truncated",
         )
       }
     }

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/InteractionExecutor.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/InteractionExecutor.kt
@@ -16,9 +16,9 @@ class InteractionExecutor(
         return
       }
 
-      is Interaction.TapOnText -> executeCommand("- tapOn: \"${interaction.text}\"")
+      is Interaction.TapOnText -> executeCommand("- tapOn: ${escapeYaml(interaction.text)}")
 
-      is Interaction.TapOnId -> executeCommand("- tapOn:\n    id: \"${interaction.resourceId}\"")
+      is Interaction.TapOnId -> executeCommand("- tapOn:\n    id: ${escapeYaml(interaction.resourceId)}")
 
       // Maestro's `scroll` has no direction param (always scrolls down).
       // Use `swipe` for directional scrolling.
@@ -28,7 +28,7 @@ class InteractionExecutor(
 
       is Interaction.LongPressOnFocused -> executeCommand("- longPressOn:\n    focused: true")
 
-      is Interaction.LongPressOnText -> executeCommand("- longPressOn: \"${interaction.text}\"")
+      is Interaction.LongPressOnText -> executeCommand("- longPressOn: ${escapeYaml(interaction.text)}")
 
       // Pull-to-refresh is a swipe down from near the top
       Interaction.PullToRefresh -> executeCommand("- swipe:\n    direction: UP")
@@ -38,5 +38,22 @@ class InteractionExecutor(
 
   private suspend fun executeCommand(command: String) {
     session.executeFlow("appId: $appId\n---\n$command")
+  }
+
+  companion object {
+    /**
+     * Escapes a string for safe use in YAML double-quoted scalars.
+     * Handles backslashes, quotes, newlines, and control characters.
+     */
+    fun escapeYaml(value: String): String {
+      val escaped = value
+        .replace("\\", "\\\\") // Backslash must be first
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+        .replace("\b", "\\b")
+      return "\"$escaped\""
+    }
   }
 }

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/NavigatorAgent.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/NavigatorAgent.kt
@@ -1,8 +1,10 @@
 package me.chrisbanes.verity.agent
 
 import ai.koog.agents.core.agent.AIAgent
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import me.chrisbanes.verity.core.interaction.Direction
 import me.chrisbanes.verity.core.model.Platform
 
@@ -38,7 +40,9 @@ class NavigatorAgent(
     val userMessage = buildUserMessage(actions, appId)
     val agent = agentFactory(systemPrompt)
     return try {
-      val response = agent.run(userMessage)
+      val response = withTimeout(TIMEOUT) {
+        agent.run(userMessage)
+      }
       cleanResponse(response)
     } finally {
       withContext(NonCancellable) { agent.close() }
@@ -61,7 +65,9 @@ class NavigatorAgent(
     val userMessage = "Target: $target\n\nCurrent screen:\n$hierarchy"
     val agent = agentFactory(systemPrompt)
     return try {
-      val response = agent.run(userMessage).trim().uppercase()
+      val response = withTimeout(TIMEOUT) {
+        agent.run(userMessage)
+      }.trim().uppercase()
       Direction.entries.firstOrNull { it.name == response }
     } finally {
       withContext(NonCancellable) { agent.close() }
@@ -69,6 +75,9 @@ class NavigatorAgent(
   }
 
   companion object {
+    /** Timeout for LLM calls - navigator uses cheap models and should be fast. */
+    private val TIMEOUT = 30.seconds
+
     fun buildSystemPrompt(
       platform: Platform,
       bundledContext: String,

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
@@ -1,6 +1,7 @@
 package me.chrisbanes.verity.agent
 
 import java.nio.file.Files
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
@@ -142,8 +143,14 @@ class Orchestrator(
     // Scroll-to-find loop (max 5 attempts)
     repeat(5) {
       val hierarchy = session.captureHierarchy()
-      val direction = navigator.suggestScrollDirection(targetText, hierarchy)
-        ?: return@repeat // LLM gave up
+      val direction = try {
+        navigator.suggestScrollDirection(targetText, hierarchy)
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
+        // LLM call failed, stop scrolling and try executing anyway
+        null
+      } ?: return@repeat // LLM gave up or failed
 
       executor.execute(Interaction.Scroll(direction))
 

--- a/verity/device/src/main/kotlin/me/chrisbanes/verity/device/DeviceSession.kt
+++ b/verity/device/src/main/kotlin/me/chrisbanes/verity/device/DeviceSession.kt
@@ -18,17 +18,25 @@ interface DeviceSession : AutoCloseable {
     val animatorScale: String,
   ) {
     init {
-      require(windowScale.matches(SCALE_PATTERN)) { "Invalid window animation scale: $windowScale" }
-      require(transitionScale.matches(SCALE_PATTERN)) {
-        "Invalid transition animation scale: $transitionScale"
-      }
-      require(animatorScale.matches(SCALE_PATTERN)) {
-        "Invalid animator duration scale: $animatorScale"
-      }
+      validateScale(windowScale, "window animation")
+      validateScale(transitionScale, "transition animation")
+      validateScale(animatorScale, "animator duration")
     }
 
     private companion object {
       val SCALE_PATTERN = Regex("""\d+(\.\d+)?""")
+
+      /** Android animation scale bounds: 0.0 (off) to 10.0 (10x speed) */
+      private const val MIN_SCALE = 0.0
+      private const val MAX_SCALE = 10.0
+
+      fun validateScale(value: String, name: String) {
+        require(value.matches(SCALE_PATTERN)) { "Invalid $name scale: $value" }
+        val numeric = value.toDouble()
+        require(numeric in MIN_SCALE..MAX_SCALE) {
+          "$name scale $value out of bounds. Expected: $MIN_SCALE to $MAX_SCALE"
+        }
+      }
     }
   }
 

--- a/verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/McpDeviceSessionManager.kt
+++ b/verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/McpDeviceSessionManager.kt
@@ -27,12 +27,13 @@ class McpDeviceSessionManager(
 ) {
 
   private val sessions = ConcurrentHashMap<UUID, SessionEntry>()
+  private val openMutex = Mutex()
 
   suspend fun open(
     platform: Platform,
     deviceId: String? = null,
     disableAnimations: Boolean = false,
-  ): SessionHandle {
+  ): SessionHandle = openMutex.withLock {
     val session = sessionFactory(platform, deviceId, disableAnimations)
     val id = UUID.randomUUID()
     val resolvedDeviceId = deviceId ?: "auto-discovered"
@@ -40,7 +41,7 @@ class McpDeviceSessionManager(
       deviceId = resolvedDeviceId,
       session = session,
     )
-    return SessionHandle(sessionId = id, deviceId = resolvedDeviceId)
+    SessionHandle(sessionId = id, deviceId = resolvedDeviceId)
   }
 
   suspend fun <T> withSession(sessionId: UUID, block: suspend (DeviceSession) -> T): T {

--- a/verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt
+++ b/verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt
@@ -20,6 +20,7 @@ import java.util.UUID
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.io.asSink
@@ -334,30 +335,31 @@ class VerityMcpServer(
           session.captureScreenshot(target)
           success("Screenshot saved to: $saveToFile")
         } else {
-          val tempPng = withContext(Dispatchers.IO) {
-            Files.createTempFile("verity-screenshot-", ".png")
-          }
+          // Use a single cleanup block to ensure all temp files are deleted
+          val tempFiles = mutableListOf<Path>()
           try {
+            val tempPng = withContext(Dispatchers.IO) {
+              Files.createTempFile("verity-screenshot-", ".png")
+            }
+            tempFiles.add(tempPng)
+
             session.captureScreenshot(tempPng)
+
             val jpegPath = withContext(Dispatchers.IO) {
               ScreenshotCompressor.compress(tempPng)
             }
-            try {
-              val bytes = withContext(Dispatchers.IO) {
-                Files.readAllBytes(jpegPath)
-              }
-              val base64 = Base64.getEncoder().encodeToString(bytes)
-              CallToolResult(
-                content = listOf(ImageContent(data = base64, mimeType = "image/jpeg")),
-              )
-            } finally {
-              withContext(Dispatchers.IO) {
-                Files.deleteIfExists(jpegPath)
-              }
+            tempFiles.add(jpegPath)
+
+            val bytes = withContext(Dispatchers.IO) {
+              Files.readAllBytes(jpegPath)
             }
+            val base64 = Base64.getEncoder().encodeToString(bytes)
+            CallToolResult(
+              content = listOf(ImageContent(data = base64, mimeType = "image/jpeg")),
+            )
           } finally {
-            withContext(Dispatchers.IO) {
-              Files.deleteIfExists(tempPng)
+            withContext(NonCancellable + Dispatchers.IO) {
+              tempFiles.forEach { Files.deleteIfExists(it) }
             }
           }
         }


### PR DESCRIPTION
This PR addresses several issues identified during a comprehensive code review of the Verity codebase. All changes maintain backward compatibility while improving security, reliability, and robustness.
## Changes

### Security
- **YAML escaping in InteractionExecutor**: Added proper escaping for user-provided text in Maestro YAML generation to prevent injection attacks via special characters (quotes, newlines, backslashes, etc.)

 ### Reliability
- **Screenshot resource cleanup**: Fixed potential resource leak in MCP server screenshot handling by using a unified cleanup approach with `NonCancellable` context
- **Session manager thread safety**: Added mutex protection around `McpDeviceSessionManager.open()` to prevent race conditions during concurrent session creation
 
### Robustness
- **LLM call timeouts**: Added 30-second timeouts to `NavigatorAgent` and `InspectorAgent` to prevent indefinite hangs on slow LLM responses
- **Error message truncation**: Limited raw LLM responses to 500 characters in error messages to prevent log flooding
- **Animation scale validation**: Added bounds checking (0.0-10.0) for Android animation scales with clear error messages
- **Scroll-to-find error handling**: Added try-catch around LLM scroll direction suggestions with proper `CancellationException` preservation
## Testing
- All changes pass `./gradlew check` (formatting, compilation, tests)
- Spotless formatting applied automatically