### PR TITLE
chore: add Renovate config to group related deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["io.grpc:grpc"],
+      "groupName": "gRPC"
+    },
+    {
+      "matchPackagePrefixes": ["dev.mobile:maestro"],
+      "groupName": "Maestro"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    }
+  ]
+}


### PR DESCRIPTION
- Groups gRPC deps (`io.grpc:grpc-*`) into a single PR
- Groups Maestro deps (`dev.mobile:maestro-*`) into a single PR  
- Groups GitHub Actions into a single PR