### PR TITLE
Support directory-based suite runs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -334,7 +334,7 @@ For MCP transport: read PNG, scale to max 1280px width (bilinear interpolation),
 ### Commands
 
 ```
-verity run <journey>           Execute a journey autonomously
+verity run <path>              Execute a journey file or directory suite autonomously
 verity list [--path <dir>]     List available journey files
 verity mcp [--transport <t>]   Start MCP server (stdio or http)
 ```
@@ -362,10 +362,13 @@ The `mcp` subcommand additionally accepts `--host` (default: 127.0.0.1) and `--p
 ### CLI Run
 
 ```
-Journey YAML
+File or directory path
     │
     ▼
-JourneyLoader.load() ──→ Journey(name, app, platform, steps)
+RunCommand.resolveJourneys() ──→ ordered List<ResolvedJourney>
+    │
+    ▼
+JourneyLoader.fromFile() ──→ Journey(name, app, platform, steps)
     │
     ▼
 JourneySegmenter.segment() ──→ List<JourneySegment>
@@ -388,6 +391,8 @@ Orchestrator.run() loops over segments:
     │
     └── Failed? → stop, skip remaining segments
 ```
+
+When the input is a directory, `verity run` discovers non-recursive `*.journey.yaml` files in deterministic filename order, executes every journey, and returns a failed process outcome if any journey fails.
 
 ### MCP Server
 

--- a/docs/superpowers/plans/2026-07-07-directory-suite-runs.md
+++ b/docs/superpowers/plans/2026-07-07-directory-suite-runs.md
@@ -1,0 +1,683 @@
+# Directory Suite Runs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `verity run <directory>` execute all matching journey files in deterministic filename order while preserving single-file behavior.
+
+**Architecture:** Keep this change in `:verity:cli`. Add small CLI-owned suite resolution/result types, make `RunCommand` resolve an input path to an ordered list of journeys, and run that list through one suite loop. Tests inject a fake suite runner so CLI behavior can be verified without a device or LLM.
+
+**Tech Stack:** Kotlin/JVM, Clikt, assertk, kotlinx.coroutines, existing Gradle wrapper tasks.
+
+---
+
+## File Structure
+
+- Modify `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+  - Add `ResolvedJourney`, `ResolvedJourneyResult`, and `SuiteRunResult`.
+  - Add path resolution helpers.
+  - Add an optional injected suite runner for CLI tests.
+  - Split production execution into a private `runSuiteWithDevice(...)` function.
+  - Print per-journey and aggregate console output.
+- Add `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`
+  - CLI-level tests for single-file input, sorted directory input, empty directory error, failure context, and aggregate failure outcome.
+- Modify `docs/architecture.md`
+  - Update the CLI command description and CLI run data flow to mention file-or-directory input and suite aggregation.
+
+---
+
+### Task 1: Add CLI-Level Tests for Suite Input Resolution and Reporting
+
+**Files:**
+- Create: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`
+- Modify: none
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt` with:
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.testing.test
+import java.io.File
+import kotlin.test.Test
+import me.chrisbanes.verity.agent.JourneyResult
+import me.chrisbanes.verity.agent.SegmentResult
+
+class RunCommandTest {
+
+  @Test
+  fun `single-file input runs one journey`() {
+    val dir = createTempDir(prefix = "verity-run-single")
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val seen = mutableListOf<String>()
+      val command = runCommand { journeys ->
+        seen += journeys.map { it.file.name }
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true))),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(seen).containsExactly("single.journey.yaml")
+      assertThat(result.output).contains("Journey: Single journey")
+      assertThat(result.output).contains("File: ${file.absolutePath}")
+      assertThat(result.output).contains("Suite result: PASSED")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `directory input runs journey files in sorted filename order`() {
+    val dir = createTempDir(prefix = "verity-run-suite")
+    try {
+      writeJourney(dir, "b.journey.yaml", "Second")
+      writeJourney(dir, "a.journey.yaml", "First")
+      writeJourney(dir, "ignored.yaml", "Ignored")
+      val seen = mutableListOf<String>()
+      val command = runCommand { journeys ->
+        seen += journeys.map { it.file.name }
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true))),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(seen).containsExactly("a.journey.yaml", "b.journey.yaml")
+      assertThat(result.output).contains("Total: 2")
+      assertThat(result.output).contains("Passed: 2")
+      assertThat(result.output).contains("Failed: 0")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `empty directory returns clear non-zero error`() {
+    val dir = createTempDir(prefix = "verity-run-empty")
+    try {
+      val result = Verity()
+        .subcommands(runCommand { error("Suite runner should not be called") })
+        .test("run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("No journey files found in: ${dir.absolutePath}")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `failing journey output includes file name journey name and failed segment`() {
+    val dir = createTempDir(prefix = "verity-run-failure")
+    try {
+      val file = writeJourney(dir, "failure.journey.yaml", "Failure journey")
+      val command = runCommand { journeys ->
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(
+                journeyName = resolved.journey.name,
+                segments = listOf(
+                  SegmentResult(index = 0, passed = true),
+                  SegmentResult(index = 1, passed = false, reasoning = "Expected text was missing"),
+                ),
+              ),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("File: ${file.absolutePath}")
+      assertThat(result.output).contains("Journey: Failure journey")
+      assertThat(result.output).contains("FAILED: Segment 1 failed")
+      assertThat(result.output).contains("Expected text was missing")
+      assertThat(result.output).contains("Suite result: FAILED")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `multiple journeys aggregate final pass fail outcome`() {
+    val dir = createTempDir(prefix = "verity-run-aggregate")
+    try {
+      writeJourney(dir, "pass.journey.yaml", "Passing journey")
+      writeJourney(dir, "fail.journey.yaml", "Failing journey")
+      val seen = mutableListOf<String>()
+      val command = runCommand { journeys ->
+        seen += journeys.map { it.file.name }
+        SuiteRunResult(
+          journeys.map { resolved ->
+            val passed = resolved.file.name == "pass.journey.yaml"
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(
+                journeyName = resolved.journey.name,
+                segments = listOf(SegmentResult(index = 0, passed = passed, reasoning = if (passed) "" else "Failed")),
+              ),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(seen).containsExactly("fail.journey.yaml", "pass.journey.yaml")
+      assertThat(result.output).contains("Total: 2")
+      assertThat(result.output).contains("Passed: 1")
+      assertThat(result.output).contains("Failed: 1")
+      assertThat(result.output).contains("Suite result: FAILED")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  private fun runCommand(
+    runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
+  ): RunCommand = RunCommand(suiteRunner = runner)
+
+  private fun writeJourney(dir: File, name: String, journeyName: String): File {
+    val file = File(dir, name)
+    file.writeText(
+      """
+      name: $journeyName
+      app: com.example.app
+      platform: android-tv
+
+      steps:
+        - [?] Home
+      """.trimIndent(),
+    )
+    return file
+  }
+}
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+
+```bash
+./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandTest
+```
+
+Expected: FAIL at compilation because `RunCommand(suiteRunner = ...)`, `ResolvedJourney`, `ResolvedJourneyResult`, and `SuiteRunResult` do not exist yet.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+git commit -m "test: cover directory suite runs"
+```
+
+---
+
+### Task 2: Add Suite Resolution and Result Types
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+- Test: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`
+
+- [ ] **Step 1: Add imports and CLI-owned suite types**
+
+In `RunCommand.kt`, add these imports:
+
+```kotlin
+import me.chrisbanes.verity.agent.JourneyResult
+import me.chrisbanes.verity.core.model.Journey
+```
+
+Then add these declarations above `class RunCommand`:
+
+```kotlin
+internal data class ResolvedJourney(
+  val file: File,
+  val journey: Journey,
+)
+
+internal data class ResolvedJourneyResult(
+  val resolvedJourney: ResolvedJourney,
+  val result: JourneyResult,
+)
+
+internal data class SuiteRunResult(
+  val results: List<ResolvedJourneyResult>,
+) {
+  val passed: Boolean get() = results.all { it.result.passed }
+  val passedCount: Int get() = results.count { it.result.passed }
+  val failedCount: Int get() = results.count { !it.result.passed }
+}
+```
+
+- [ ] **Step 2: Add injectable constructor parameters**
+
+Change the class declaration from:
+
+```kotlin
+class RunCommand : CliktCommand(name = "run") {
+```
+
+to:
+
+```kotlin
+class RunCommand(
+  private val loadJourney: (File) -> Journey = JourneyLoader::fromFile,
+  private val listJourneyFiles: (File) -> List<File> = JourneyLoader::listJourneyFiles,
+  private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
+) : CliktCommand(name = "run") {
+```
+
+- [ ] **Step 3: Add path resolution helpers**
+
+Inside `RunCommand`, below the `journeyPath` property, add:
+
+```kotlin
+  private fun resolveJourneys(path: File): List<ResolvedJourney> {
+    if (!path.exists()) {
+      throw CliktError("Journey path not found: ${path.absolutePath}")
+    }
+
+    return when {
+      path.isDirectory -> {
+        val files = listJourneyFiles(path)
+        if (files.isEmpty()) {
+          throw CliktError("No journey files found in: ${path.absolutePath}")
+        }
+        files.map { file -> ResolvedJourney(file = file, journey = loadJourney(file)) }
+      }
+
+      path.isFile -> listOf(ResolvedJourney(file = path, journey = loadJourney(path)))
+
+      else -> throw CliktError("Journey path is not a file or directory: ${path.absolutePath}")
+    }
+  }
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run:
+
+```bash
+./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandTest
+```
+
+Expected: FAIL because `RunCommand.run()` still ignores `resolveJourneys(...)` and does not call `suiteRunner`.
+
+- [ ] **Step 5: Commit the suite types and resolver**
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+git commit -m "feat: resolve run inputs as journeys"
+```
+
+---
+
+### Task 3: Wire `RunCommand` Through the Suite Runner
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+- Test: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`
+
+- [ ] **Step 1: Replace `run()` with suite-aware control flow**
+
+Replace the body of `override fun run() = runBlocking { ... }` with:
+
+```kotlin
+  override fun run() = runBlocking {
+    val parent = currentContext.parent?.command as Verity
+
+    val path = journeyPath?.let { File(it) }
+      ?: throw UsageError("Journey path required. Use: verity run <path>")
+    val journeys = resolveJourneys(path)
+
+    val suiteResult = suiteRunner?.invoke(journeys)
+      ?: runSuiteWithDevice(parent = parent, journeys = journeys)
+
+    printSuiteResult(suiteResult)
+
+    if (!suiteResult.passed) {
+      throw CliktError("Journey suite failed")
+    }
+  }
+```
+
+- [ ] **Step 2: Add console reporting**
+
+Inside `RunCommand`, add:
+
+```kotlin
+  private fun printSuiteResult(suiteResult: SuiteRunResult) {
+    suiteResult.results.forEachIndexed { index, journeyResult ->
+      val resolved = journeyResult.resolvedJourney
+      val result = journeyResult.result
+
+      if (index > 0) echo()
+      echo("File: ${resolved.file.absolutePath}")
+      echo("Journey: ${resolved.journey.name}")
+      echo("App: ${resolved.journey.app}")
+      echo("Platform: ${resolved.journey.platform}")
+
+      if (result.passed) {
+        echo("PASSED: All ${result.segments.size} segments passed")
+      } else {
+        echo("FAILED: Segment ${result.failedAt} failed")
+        result.segments.filter { !it.passed }.forEach { seg ->
+          echo("  Segment ${seg.index}: ${seg.reasoning}")
+        }
+      }
+    }
+
+    echo()
+    echo("Suite result: ${if (suiteResult.passed) "PASSED" else "FAILED"}")
+    echo("Total: ${suiteResult.results.size}")
+    echo("Passed: ${suiteResult.passedCount}")
+    echo("Failed: ${suiteResult.failedCount}")
+  }
+```
+
+- [ ] **Step 3: Extract production execution into `runSuiteWithDevice`**
+
+Inside `RunCommand`, add this private function:
+
+```kotlin
+  private suspend fun runSuiteWithDevice(
+    parent: Verity,
+    journeys: List<ResolvedJourney>,
+  ): SuiteRunResult {
+    val config = VerityConfig.loadOrDefault(File("verity/config.yaml"))
+    val provider = resolveProvider(parent.provider, config)
+
+    val apiKey = parent.apiKey ?: System.getenv(provider.envVar)
+    if (provider.requiresAuth && apiKey == null) {
+      throw UsageError("API key required. Set ${provider.envVar} or use --api-key")
+    }
+
+    val navigatorModel = resolveModel(
+      cliModel = parent.navigatorModel,
+      configModel = config.navigatorModel,
+      default = provider.defaultNavigatorModel,
+      provider = provider,
+    )
+    val inspectorModel = resolveModel(
+      cliModel = parent.inspectorModel,
+      configModel = config.inspectorModel,
+      default = provider.defaultInspectorModel,
+      provider = provider,
+    )
+
+    echo("Provider: ${provider.name}")
+    echo("Navigator model: ${navigatorModel.id}")
+    echo("Inspector model: ${inspectorModel.id}")
+
+    val firstJourney = journeys.first().journey
+    val platform = parent.platform ?: firstJourney.platform
+    val session = DeviceSessionFactory.connect(
+      platform = platform,
+      deviceId = parent.device,
+      disableAnimations = parent.noAnimations,
+    )
+
+    val executor = SingleLLMPromptExecutor(provider.createClient(apiKey ?: ""))
+
+    session.use {
+      val injectedContext = parent.contextPath?.let { ContextLoader.load(File(it)) } ?: ""
+
+      val orchestrator = Orchestrator(
+        session = session,
+        navigatorFactory = {
+          NavigatorAgent(
+            bundledContext = if (parent.noBundledContext) "" else ContextLoader.loadBundled(),
+            agentFactory = { systemPrompt ->
+              AIAgent(
+                promptExecutor = executor,
+                llmModel = navigatorModel,
+                systemPrompt = systemPrompt,
+              )
+            },
+          )
+        },
+        inspectorFactory = {
+          InspectorAgent(
+            treeAgentFactory = {
+              AIAgent(
+                promptExecutor = executor,
+                llmModel = inspectorModel,
+                systemPrompt = InspectorAgent.SYSTEM_PROMPT,
+              )
+            },
+            evaluateVisualContent = { systemPrompt, userMessage, screenshotPath ->
+              val p = prompt("visual-eval") {
+                system(systemPrompt)
+                user {
+                  text(userMessage)
+                  image(kotlinx.io.files.Path(screenshotPath.toString()))
+                }
+              }
+              val responses = executor.execute(p, inspectorModel)
+              responses.last().content
+            },
+          )
+        },
+        context = injectedContext,
+      )
+
+      return SuiteRunResult(
+        journeys.map { resolved ->
+          ResolvedJourneyResult(
+            resolvedJourney = resolved,
+            result = orchestrator.run(resolved.journey),
+          )
+        },
+      )
+    }
+  }
+```
+
+- [ ] **Step 4: Remove obsolete single-file execution code**
+
+After adding `runSuiteWithDevice`, delete the old inline code in `run()` that loaded one file, connected a session, ran one journey, and printed only one result. `RunCommand.kt` should have exactly one `override fun run()` implementation and no old `val file = ...` block.
+
+- [ ] **Step 5: Run the focused CLI tests**
+
+Run:
+
+```bash
+./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit suite runner wiring**
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+git commit -m "feat: run journey directories as suites"
+```
+
+---
+
+### Task 4: Update Architecture Documentation
+
+**Files:**
+- Modify: `docs/architecture.md`
+- Test: none
+
+- [ ] **Step 1: Update the CLI command list**
+
+In `docs/architecture.md`, change:
+
+```markdown
+verity run <journey>           Execute a journey autonomously
+```
+
+to:
+
+```markdown
+verity run <path>              Execute a journey file or directory suite autonomously
+```
+
+- [ ] **Step 2: Update the CLI run data flow**
+
+In the `### CLI Run` data-flow section, replace:
+
+```markdown
+Journey YAML
+    │
+    ▼
+JourneyLoader.load() ──→ Journey(name, app, platform, steps)
+```
+
+with:
+
+```markdown
+File or directory path
+    │
+    ▼
+RunCommand.resolveJourneys() ──→ ordered List<ResolvedJourney>
+    │
+    ▼
+JourneyLoader.fromFile() ──→ Journey(name, app, platform, steps)
+```
+
+Then add this sentence after the diagram:
+
+```markdown
+When the input is a directory, `verity run` discovers non-recursive `*.journey.yaml` files in deterministic filename order, executes every journey, and returns a failed process outcome if any journey fails.
+```
+
+- [ ] **Step 3: Run docs diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit architecture docs**
+
+```bash
+git add docs/architecture.md
+git commit -m "docs: describe directory suite runs"
+```
+
+---
+
+### Task 5: Run Formatting and Full Verification
+
+**Files:**
+- Modify: any files changed by Spotless
+- Test: all changed behavior
+
+- [ ] **Step 1: Apply formatting**
+
+Run:
+
+```bash
+./gradlew spotlessApply
+```
+
+Expected: SUCCESS.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full checks**
+
+Run:
+
+```bash
+./gradlew check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only intended files are changed if Spotless adjusted formatting after the previous commits.
+
+- [ ] **Step 5: Commit any final formatting changes**
+
+If `git status --short` shows changes after `spotlessApply`, run:
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt docs/architecture.md
+git commit -m "style: format directory suite changes"
+```
+
+If `git status --short` is clean, do not create an empty commit.
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Single-file behavior is preserved by resolving file input to a one-item `List<ResolvedJourney>` and still calling `Orchestrator.run(journey)`.
+- Directory behavior is covered by `JourneyLoader.listJourneyFiles(directory)`, sorted execution tests, and suite loop wiring.
+- Empty-directory failure is covered by `resolveJourneys(...)` and a CLI-level non-zero test.
+- Failure output includes source file, journey name, failed segment, and segment reasoning.
+- Aggregate final pass/fail behavior is covered by a multi-journey CLI test.
+- #49 artifact persistence and JSON results are not introduced.
+
+Placeholder scan:
+
+- No TBD/TODO/later placeholders.
+- Every code-edit step includes concrete code.
+- Every verification step includes exact commands and expected outcomes.
+
+Type consistency:
+
+- `ResolvedJourney`, `ResolvedJourneyResult`, and `SuiteRunResult` are introduced before tests rely on them passing.
+- `SuiteRunResult.passed`, `passedCount`, and `failedCount` match the reporting code.
+- `suiteRunner` signature matches the tests and `RunCommand.run()` invocation.

--- a/docs/superpowers/specs/2026-07-07-directory-suite-runs-design.md
+++ b/docs/superpowers/specs/2026-07-07-directory-suite-runs-design.md
@@ -1,0 +1,89 @@
+# Directory Suite Runs Design
+
+## Goal
+
+Support `verity run <directory>` by resolving all matching journey files in deterministic filename order and executing them as a console-oriented suite.
+
+This change is limited to input resolution, ordered execution, failure reporting, and CLI-level coverage for GitHub issue #48. Artifact directories, persisted Maestro flows, and structured JSON result files are intentionally out of scope and belong to #49.
+
+## Public Behavior
+
+`verity run <path>` accepts either:
+
+- a single `*.journey.yaml` file, preserving current behavior
+- a directory containing `*.journey.yaml` files
+
+For directory input, journey files are discovered non-recursively with `JourneyLoader.listJourneyFiles(directory)`, which already filters to regular files ending in `.journey.yaml` and sorts by filename. Empty directories produce a clear `CliktError` and a non-zero exit code.
+
+Directory suites continue after an individual journey fails. The final process outcome is failed if any journey failed.
+
+## CLI Architecture
+
+Add a small CLI-owned resolved input model, for example:
+
+```kotlin
+data class ResolvedJourney(
+  val file: File,
+  val journey: Journey,
+)
+```
+
+`RunCommand` should split into three responsibilities:
+
+1. Resolve the input path into an ordered `List<ResolvedJourney>`.
+2. Build shared runtime dependencies once: provider, models, device session, prompt executor, context, and orchestrator factories.
+3. Execute the ordered journeys and print per-journey plus aggregate console output.
+
+The runner should be shaped around an ordered list of resolved journeys so #49 can later attach artifact and result writing without changing directory discovery or command resolution.
+
+## Execution Flow
+
+Single-file input resolves to one `ResolvedJourney` and runs exactly as today.
+
+Directory input resolves to all matching journeys, then runs each journey sequentially using the same device session and LLM executor. Each journey is still passed to `Orchestrator.run(journey)`, so segment execution and stop-on-failed-segment behavior remain unchanged inside a single journey.
+
+The suite-level loop continues to the next journey after a failed journey and records the result for the final summary.
+
+## Console Output
+
+Each journey should print enough context to identify what is running:
+
+- source file path or filename
+- journey name
+- app
+- platform
+
+On failure, output must include:
+
+- source file
+- journey name
+- failed segment index
+- failed segment reasoning
+
+At the end, print an aggregate summary with total, passed, and failed counts. If any journey failed, throw a `CliktError` after printing the summary so the command exits non-zero.
+
+## Error Handling
+
+Missing input remains a usage error.
+
+Missing paths and unsupported paths produce clear `CliktError` messages. A file path should still be expected to be a journey file. A directory with no matching journey files should fail with a clear message such as:
+
+```text
+No journey files found in: <directory>
+```
+
+Journey parsing errors can continue to surface from `JourneyLoader.fromFile(file)` and should naturally include the file being resolved by wrapping only if the current message lacks enough path context.
+
+## Testing
+
+Add CLI-level tests around command behavior rather than only loader or orchestrator behavior. To avoid real devices and LLMs, make `RunCommand` accept injected functions for resolving or executing journeys, with production defaults.
+
+Coverage should include:
+
+- single-file input still resolves and runs one journey
+- directory input runs files in sorted filename order
+- empty directory returns a clear non-zero error
+- failing journey output includes file, journey name, and failed segment
+- multiple journeys aggregate the final pass/fail outcome
+
+Keep assertions in assertk, matching existing project test style.

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -12,16 +12,60 @@ import com.github.ajalt.clikt.parameters.arguments.optional
 import java.io.File
 import kotlinx.coroutines.runBlocking
 import me.chrisbanes.verity.agent.InspectorAgent
+import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.NavigatorAgent
 import me.chrisbanes.verity.agent.Orchestrator
 import me.chrisbanes.verity.core.context.ContextLoader
 import me.chrisbanes.verity.core.journey.JourneyLoader
+import me.chrisbanes.verity.core.model.Journey
 import me.chrisbanes.verity.device.DeviceSessionFactory
 
-class RunCommand : CliktCommand(name = "run") {
+data class ResolvedJourney(
+  val file: File,
+  val journey: Journey,
+)
+
+data class ResolvedJourneyResult(
+  val resolvedJourney: ResolvedJourney,
+  val result: JourneyResult,
+)
+
+data class SuiteRunResult(
+  val results: List<ResolvedJourneyResult>,
+) {
+  val passed: Boolean get() = results.all { it.result.passed }
+  val passedCount: Int get() = results.count { it.result.passed }
+  val failedCount: Int get() = results.count { !it.result.passed }
+}
+
+class RunCommand(
+  private val loadJourney: (File) -> Journey = JourneyLoader::fromFile,
+  private val listJourneyFiles: (File) -> List<File> = JourneyLoader::listJourneyFiles,
+  private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
+) : CliktCommand(name = "run") {
   override fun help(context: Context): String = "Execute a journey file against a connected device"
 
   private val journeyPath by argument("journey", help = "Path to .journey.yaml file").optional()
+
+  private fun resolveJourneys(path: File): List<ResolvedJourney> {
+    if (!path.exists()) {
+      throw CliktError("Journey path not found: ${path.absolutePath}")
+    }
+
+    return when {
+      path.isDirectory -> {
+        val files = listJourneyFiles(path)
+        if (files.isEmpty()) {
+          throw CliktError("No journey files found in: ${path.absolutePath}")
+        }
+        files.map { file -> ResolvedJourney(file = file, journey = loadJourney(file)) }
+      }
+
+      path.isFile -> listOf(ResolvedJourney(file = path, journey = loadJourney(path)))
+
+      else -> throw CliktError("Journey path is not a file or directory: ${path.absolutePath}")
+    }
+  }
 
   override fun run() = runBlocking {
     val parent = currentContext.parent?.command as Verity

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -59,12 +59,25 @@ class RunCommand(
           throw CliktError("No journey files found in: ${path.absolutePath}")
         }
         files.map { file -> ResolvedJourney(file = file, journey = loadJourney(file)) }
+          .also(::requireSinglePlatform)
       }
 
       path.isFile -> listOf(ResolvedJourney(file = path, journey = loadJourney(path)))
 
       else -> throw CliktError("Journey path is not a file or directory: ${path.absolutePath}")
     }
+  }
+
+  private fun requireSinglePlatform(journeys: List<ResolvedJourney>) {
+    val platforms = journeys.map { it.journey.platform }.distinct()
+    if (platforms.size <= 1) return
+
+    val platformDetails = journeys.joinToString(separator = ", ") { resolved ->
+      "${resolved.file.name}: ${resolved.journey.platform}"
+    }
+    throw CliktError(
+      "Directory suites must use a single platform. Found: $platformDetails",
+    )
   }
 
   override fun run() = runBlocking {

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -70,6 +70,52 @@ class RunCommand(
   override fun run() = runBlocking {
     val parent = currentContext.parent?.command as Verity
 
+    val path = journeyPath?.let { File(it) }
+      ?: throw UsageError("Journey path required. Use: verity run <path>")
+    val journeys = resolveJourneys(path)
+
+    val suiteResult = suiteRunner?.invoke(journeys)
+      ?: runSuiteWithDevice(parent = parent, journeys = journeys)
+
+    printSuiteResult(suiteResult)
+
+    if (!suiteResult.passed) {
+      throw CliktError("Journey suite failed")
+    }
+  }
+
+  private fun printSuiteResult(suiteResult: SuiteRunResult) {
+    suiteResult.results.forEachIndexed { index, journeyResult ->
+      val resolved = journeyResult.resolvedJourney
+      val result = journeyResult.result
+
+      if (index > 0) echo()
+      echo("File: ${resolved.file.absolutePath}")
+      echo("Journey: ${resolved.journey.name}")
+      echo("App: ${resolved.journey.app}")
+      echo("Platform: ${resolved.journey.platform}")
+
+      if (result.passed) {
+        echo("PASSED: All ${result.segments.size} segments passed")
+      } else {
+        echo("FAILED: Segment ${result.failedAt} failed")
+        result.segments.filter { !it.passed }.forEach { seg ->
+          echo("  Segment ${seg.index}: ${seg.reasoning}")
+        }
+      }
+    }
+
+    echo()
+    echo("Suite result: ${if (suiteResult.passed) "PASSED" else "FAILED"}")
+    echo("Total: ${suiteResult.results.size}")
+    echo("Passed: ${suiteResult.passedCount}")
+    echo("Failed: ${suiteResult.failedCount}")
+  }
+
+  private suspend fun runSuiteWithDevice(
+    parent: Verity,
+    journeys: List<ResolvedJourney>,
+  ): SuiteRunResult {
     val config = VerityConfig.loadOrDefault(File("verity/config.yaml"))
     val provider = resolveProvider(parent.provider, config)
 
@@ -81,19 +127,12 @@ class RunCommand(
     val navigatorModel = resolveModel(parent.navigatorModel, config.navigatorModel, provider.defaultNavigatorModel, provider)
     val inspectorModel = resolveModel(parent.inspectorModel, config.inspectorModel, provider.defaultInspectorModel, provider)
 
-    val file = journeyPath?.let { File(it) }
-      ?: throw UsageError("Journey path required. Use: verity run <path.journey.yaml>")
-    if (!file.exists()) throw CliktError("Journey file not found: $file")
-
-    val journey = JourneyLoader.fromFile(file)
     echo("Provider: ${provider.name}")
     echo("Navigator model: ${navigatorModel.id}")
     echo("Inspector model: ${inspectorModel.id}")
-    echo("Running journey: ${journey.name}")
-    echo("App: ${journey.app}")
-    echo("Platform: ${journey.platform}")
 
-    val platform = parent.platform ?: journey.platform
+    val firstJourney = journeys.first().journey
+    val platform = parent.platform ?: firstJourney.platform
     val session = DeviceSessionFactory.connect(
       platform = platform,
       deviceId = parent.device,
@@ -144,17 +183,14 @@ class RunCommand(
         context = injectedContext,
       )
 
-      val result = orchestrator.run(journey)
-
-      echo()
-      if (result.passed) {
-        echo("PASSED: All ${result.segments.size} segments passed")
-      } else {
-        echo("FAILED: Segment ${result.failedAt} failed")
-        result.segments.filter { !it.passed }.forEach { seg ->
-          echo("  Segment ${seg.index}: ${seg.reasoning}")
-        }
-      }
+      return SuiteRunResult(
+        journeys.map { resolved ->
+          ResolvedJourneyResult(
+            resolvedJourney = resolved,
+            result = orchestrator.run(resolved.journey),
+          )
+        },
+      )
     }
   }
 }

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -183,7 +183,7 @@ class RunCommandTest {
       platform: android-tv
 
       steps:
-        - [?] Home
+        - "[?] Home"
       """.trimIndent(),
     )
     return file

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isEqualTo
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.testing.test
 import java.io.File
+import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.SegmentResult
@@ -15,7 +16,7 @@ class RunCommandTest {
 
   @Test
   fun `single-file input runs one journey`() {
-    val dir = createTempDir(prefix = "verity-run-single")
+    val dir = createTempDirectory("verity-run-single").toFile()
     try {
       val file = writeJourney(dir, "single.journey.yaml", "Single journey")
       val seen = mutableListOf<String>()
@@ -47,7 +48,7 @@ class RunCommandTest {
 
   @Test
   fun `directory input runs journey files in sorted filename order`() {
-    val dir = createTempDir(prefix = "verity-run-suite")
+    val dir = createTempDirectory("verity-run-suite").toFile()
     try {
       writeJourney(dir, "b.journey.yaml", "Second")
       writeJourney(dir, "a.journey.yaml", "First")
@@ -81,7 +82,7 @@ class RunCommandTest {
 
   @Test
   fun `empty directory returns clear non-zero error`() {
-    val dir = createTempDir(prefix = "verity-run-empty")
+    val dir = createTempDirectory("verity-run-empty").toFile()
     try {
       val result = Verity()
         .subcommands(runCommand { error("Suite runner should not be called") })
@@ -96,7 +97,7 @@ class RunCommandTest {
 
   @Test
   fun `failing journey output includes file name journey name and failed segment`() {
-    val dir = createTempDir(prefix = "verity-run-failure")
+    val dir = createTempDirectory("verity-run-failure").toFile()
     try {
       val file = writeJourney(dir, "failure.journey.yaml", "Failure journey")
       val command = runCommand { journeys ->
@@ -133,7 +134,7 @@ class RunCommandTest {
 
   @Test
   fun `multiple journeys aggregate final pass fail outcome`() {
-    val dir = createTempDir(prefix = "verity-run-aggregate")
+    val dir = createTempDirectory("verity-run-aggregate").toFile()
     try {
       writeJourney(dir, "pass.journey.yaml", "Passing journey")
       writeJourney(dir, "fail.journey.yaml", "Failing journey")

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -1,0 +1,190 @@
+package me.chrisbanes.verity.cli
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.testing.test
+import java.io.File
+import kotlin.test.Test
+import me.chrisbanes.verity.agent.JourneyResult
+import me.chrisbanes.verity.agent.SegmentResult
+
+class RunCommandTest {
+
+  @Test
+  fun `single-file input runs one journey`() {
+    val dir = createTempDir(prefix = "verity-run-single")
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val seen = mutableListOf<String>()
+      val command = runCommand { journeys ->
+        seen += journeys.map { it.file.name }
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true))),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(seen).containsExactly("single.journey.yaml")
+      assertThat(result.output).contains("Journey: Single journey")
+      assertThat(result.output).contains("File: ${file.absolutePath}")
+      assertThat(result.output).contains("Suite result: PASSED")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `directory input runs journey files in sorted filename order`() {
+    val dir = createTempDir(prefix = "verity-run-suite")
+    try {
+      writeJourney(dir, "b.journey.yaml", "Second")
+      writeJourney(dir, "a.journey.yaml", "First")
+      writeJourney(dir, "ignored.yaml", "Ignored")
+      val seen = mutableListOf<String>()
+      val command = runCommand { journeys ->
+        seen += journeys.map { it.file.name }
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true))),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(seen).containsExactly("a.journey.yaml", "b.journey.yaml")
+      assertThat(result.output).contains("Total: 2")
+      assertThat(result.output).contains("Passed: 2")
+      assertThat(result.output).contains("Failed: 0")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `empty directory returns clear non-zero error`() {
+    val dir = createTempDir(prefix = "verity-run-empty")
+    try {
+      val result = Verity()
+        .subcommands(runCommand { error("Suite runner should not be called") })
+        .test("run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("No journey files found in: ${dir.absolutePath}")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `failing journey output includes file name journey name and failed segment`() {
+    val dir = createTempDir(prefix = "verity-run-failure")
+    try {
+      val file = writeJourney(dir, "failure.journey.yaml", "Failure journey")
+      val command = runCommand { journeys ->
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(
+                journeyName = resolved.journey.name,
+                segments = listOf(
+                  SegmentResult(index = 0, passed = true),
+                  SegmentResult(index = 1, passed = false, reasoning = "Expected text was missing"),
+                ),
+              ),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("File: ${file.absolutePath}")
+      assertThat(result.output).contains("Journey: Failure journey")
+      assertThat(result.output).contains("FAILED: Segment 1 failed")
+      assertThat(result.output).contains("Expected text was missing")
+      assertThat(result.output).contains("Suite result: FAILED")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `multiple journeys aggregate final pass fail outcome`() {
+    val dir = createTempDir(prefix = "verity-run-aggregate")
+    try {
+      writeJourney(dir, "pass.journey.yaml", "Passing journey")
+      writeJourney(dir, "fail.journey.yaml", "Failing journey")
+      val seen = mutableListOf<String>()
+      val command = runCommand { journeys ->
+        seen += journeys.map { it.file.name }
+        SuiteRunResult(
+          journeys.map { resolved ->
+            val passed = resolved.file.name == "pass.journey.yaml"
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(
+                journeyName = resolved.journey.name,
+                segments = listOf(SegmentResult(index = 0, passed = passed, reasoning = if (passed) "" else "Failed")),
+              ),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(seen).containsExactly("fail.journey.yaml", "pass.journey.yaml")
+      assertThat(result.output).contains("Total: 2")
+      assertThat(result.output).contains("Passed: 1")
+      assertThat(result.output).contains("Failed: 1")
+      assertThat(result.output).contains("Suite result: FAILED")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  private fun runCommand(
+    runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
+  ): RunCommand = RunCommand(suiteRunner = runner)
+
+  private fun writeJourney(dir: File, name: String, journeyName: String): File {
+    val file = File(dir, name)
+    file.writeText(
+      """
+      name: $journeyName
+      app: com.example.app
+      platform: android-tv
+
+      steps:
+        - [?] Home
+      """.trimIndent(),
+    )
+    return file
+  }
+}

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -96,6 +96,26 @@ class RunCommandTest {
   }
 
   @Test
+  fun `directory input rejects mixed journey platforms`() {
+    val dir = createTempDirectory("verity-run-mixed-platforms").toFile()
+    try {
+      writeJourney(dir, "android.journey.yaml", "Android journey", platform = "android-tv")
+      writeJourney(dir, "ios.journey.yaml", "iOS journey", platform = "ios")
+
+      val result = Verity()
+        .subcommands(runCommand { error("Suite runner should not be called") })
+        .test("run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("Directory suites must use a single platform")
+      assertThat(result.output).contains("android.journey.yaml: ANDROID_TV")
+      assertThat(result.output).contains("ios.journey.yaml: IOS")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `failing journey output includes file name journey name and failed segment`() {
     val dir = createTempDirectory("verity-run-failure").toFile()
     try {
@@ -174,13 +194,18 @@ class RunCommandTest {
     runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
   ): RunCommand = RunCommand(suiteRunner = runner)
 
-  private fun writeJourney(dir: File, name: String, journeyName: String): File {
+  private fun writeJourney(
+    dir: File,
+    name: String,
+    journeyName: String,
+    platform: String = "android-tv",
+  ): File {
     val file = File(dir, name)
     file.writeText(
       """
       name: $journeyName
       app: com.example.app
-      platform: android-tv
+      platform: $platform
 
       steps:
         - "[?] Home"


### PR DESCRIPTION
## Summary

- Add `verity run <directory>` support by resolving directory inputs to ordered `*.journey.yaml` suites.
- Preserve single-file `verity run <file.journey.yaml>` behavior while adding suite-level pass/fail aggregation.
- Include file, journey name, failed segment, and reasoning in console output for failing journeys.
- Update architecture docs for file-or-directory CLI input.

Fixes #48.

## Test Plan

- `./gradlew spotlessApply`
- `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandTest`
- `./gradlew check`