### PR TITLE
Add project context validation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -338,7 +338,7 @@ For MCP transport: read PNG, scale to max 1280px width (bilinear interpolation),
 | `check_visible` | session_id, text | true/false | Deterministic, case-insensitive |
 | `check_focused` | session_id, text | true/false | Lenient ancestor/sibling/child check |
 | `run_loop` | session_id, action, until | SATISFIED/NOT + iterations | Optional: max, wait_ms |
-| `get_context` | — | bundled defaults + markdown context text | Optional: path |
+| `get_context` | optional path | loaded-file metadata + bundled defaults + markdown context text | Required context can error |
 
 ---
 
@@ -362,11 +362,25 @@ verity mcp [--transport <t>]   Start MCP server (stdio or http)
 --inspector-model <id>   Model for assertion evaluation (capable tier)
 --api-key <key>          LLM API key (or ANTHROPIC_API_KEY env var)
 --context-path <dir>     Optional path to additional context markdown files
+--require-context        Fail if project context is missing or contains no markdown files
 --no-animations          Disable device animations during run
 --no-bundled-context     Skip bundled context resources
 ```
 
 The `mcp` subcommand additionally accepts `--host` (default: 127.0.0.1) and `--port` (default: 8080) for HTTP transport.
+
+### Configuration
+
+`verity/config.yaml` can provide defaults for provider and model selection:
+
+```yaml
+provider: anthropic
+navigator-model: claude-haiku-4-5
+inspector-model: claude-opus-4-5
+require-context: true
+```
+
+`require-context` makes `--context-path` mandatory for workflows that depend on project context. The CLI `--require-context` flag also enables this behavior for one invocation.
 
 ---
 
@@ -382,6 +396,13 @@ RunCommand.resolveJourneys() ──→ ordered List<ResolvedJourney>
     │
     ▼
 JourneyLoader.fromFile() ──→ Journey(name, app, platform, steps)
+    │
+    ▼
+ContextLoader.loadProject()
+    ├── LOADED → report loaded markdown files, inject text into NavigatorAgent
+    ├── NOT_CONFIGURED → optional explicit status or required error
+    ├── MISSING_DIRECTORY → optional explicit status or required error
+    └── EMPTY_DIRECTORY → optional explicit status or required error
     │
     ▼
 JourneySegmenter.segment() ──→ List<JourneySegment>

--- a/docs/superpowers/plans/2026-07-07-project-context-validation.md
+++ b/docs/superpowers/plans/2026-07-07-project-context-validation.md
@@ -1,0 +1,849 @@
+# Project Context Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add structured project-context validation, required-context configuration, and loaded-file reporting for CLI runs and MCP `get_context`.
+
+**Architecture:** Keep context discovery in `:verity:core` by extending `ContextLoader` with a structured `ContextBundle` result and a typed validation exception. Wire the shared result into CLI and MCP call sites so both surfaces use the same validation rules while preserving optional-context behavior.
+
+**Tech Stack:** Kotlin/JVM 21, Clikt, kotlinx.coroutines, Kaml serialization, MCP Kotlin SDK, assertk, Gradle via `./gradlew`.
+
+---
+
+## File Structure
+
+- Modify `verity/core/src/main/kotlin/me/chrisbanes/verity/core/context/ContextLoader.kt`
+  - Owns bundled context loading and project markdown context loading.
+  - Adds `ContextBundle`, `ContextStatus`, and `ContextValidationException`.
+- Modify `verity/core/src/test/kotlin/me/chrisbanes/verity/core/context/ContextLoaderTest.kt`
+  - Covers optional and required context validation.
+- Modify `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/VerityConfig.kt`
+  - Adds `require-context` config parsing and `resolveRequiredContext`.
+- Modify `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityConfigTest.kt`
+  - Covers config parsing and precedence helper.
+- Modify `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/Verity.kt`
+  - Adds shared `--require-context`.
+- Modify `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityTest.kt`
+  - Covers help output for the new flag.
+- Modify `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+  - Validates context before device connection and prints context status.
+- Modify `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt`
+  - Adds a command-level failure test for required missing context.
+- Modify `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/McpCommand.kt`
+  - Resolves config and passes required context into the MCP server.
+- Modify `verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt`
+  - Adds required-context validation and loaded-file reporting in `get_context`.
+- Modify `verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/VerityMcpServerTest.kt`
+  - Covers optional missing context, loaded files, and required missing context.
+- Modify `docs/architecture.md`
+  - Documents `--require-context`, `require-context`, context statuses, and `get_context` metadata.
+
+---
+
+### Task 1: Core Context Validation Contract
+
+**Files:**
+- Modify: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/context/ContextLoader.kt`
+- Test: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/context/ContextLoaderTest.kt`
+
+- [ ] **Step 1: Write failing tests for structured optional validation**
+
+Add these imports to `ContextLoaderTest.kt`:
+
+```kotlin
+import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+```
+
+Add these tests to `ContextLoaderTest`:
+
+```kotlin
+@Test
+fun `loadProject returns not configured for optional null directory`() {
+  val bundle = ContextLoader.loadProject(directory = null, required = false)
+
+  assertThat(bundle.status).isEqualTo(ContextStatus.NOT_CONFIGURED)
+  assertThat(bundle.text).isEmpty()
+  assertThat(bundle.loadedFiles).isEmpty()
+}
+
+@Test
+fun `loadProject returns missing directory for optional nonexistent path`() {
+  val directory = File("/nonexistent/path")
+
+  val bundle = ContextLoader.loadProject(directory = directory, required = false)
+
+  assertThat(bundle.status).isEqualTo(ContextStatus.MISSING_DIRECTORY)
+  assertThat(bundle.text).isEmpty()
+  assertThat(bundle.loadedFiles).isEmpty()
+}
+
+@Test
+fun `loadProject returns empty directory for optional directory without markdown files`() {
+  val dir = kotlin.io.path.createTempDirectory("empty-context").toFile()
+  try {
+    File(dir, "notes.txt").writeText("ignored")
+
+    val bundle = ContextLoader.loadProject(directory = dir, required = false)
+
+    assertThat(bundle.status).isEqualTo(ContextStatus.EMPTY_DIRECTORY)
+    assertThat(bundle.text).isEmpty()
+    assertThat(bundle.loadedFiles).isEmpty()
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+```
+
+- [ ] **Step 2: Write failing tests for loaded files and required failures**
+
+Add these tests to `ContextLoaderTest`:
+
+```kotlin
+@Test
+fun `loadProject reports loaded markdown files in deterministic order`() {
+  val dir = createTempContextDir(
+    "b.markdown" to "Section B",
+    "a.md" to "Section A",
+    "notes.txt" to "ignored",
+  )
+  try {
+    val bundle = ContextLoader.loadProject(directory = dir, required = true)
+
+    assertThat(bundle.status).isEqualTo(ContextStatus.LOADED)
+    assertThat(bundle.text).isEqualTo("Section A\n\nSection B")
+    assertThat(bundle.loadedFiles.map { it.name }).containsExactly("a.md", "b.markdown")
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+
+@Test
+fun `loadProject throws clear error when required context is not configured`() {
+  assertThat {
+    ContextLoader.loadProject(directory = null, required = true)
+  }.isFailure().hasMessage("Required project context is not configured. Set --context-path before using --require-context.")
+}
+
+@Test
+fun `loadProject throws clear error when required context directory is missing`() {
+  val directory = File("/nonexistent/path")
+
+  assertThat {
+    ContextLoader.loadProject(directory = directory, required = true)
+  }.isFailure().hasMessage(
+    "Required project context directory does not exist or is not a directory: ${directory.absolutePath}",
+  )
+}
+
+@Test
+fun `loadProject throws clear error when required context directory is empty`() {
+  val dir = kotlin.io.path.createTempDirectory("required-empty-context").toFile()
+  try {
+    assertThat {
+      ContextLoader.loadProject(directory = dir, required = true)
+    }.isFailure().hasMessage(
+      "Required project context directory contains no markdown files: ${dir.absolutePath}",
+    )
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+```
+
+- [ ] **Step 3: Run the core context tests and verify they fail**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:core:test --tests me.chrisbanes.verity.core.context.ContextLoaderTest
+```
+
+Expected: FAIL because `loadProject`, `ContextStatus`, and `ContextValidationException` do not exist yet.
+
+- [ ] **Step 4: Implement the structured context loader**
+
+Replace `ContextLoader.kt` with:
+
+```kotlin
+package me.chrisbanes.verity.core.context
+
+import java.io.File
+
+data class ContextBundle(
+  val text: String,
+  val loadedFiles: List<File>,
+  val status: ContextStatus,
+)
+
+enum class ContextStatus {
+  LOADED,
+  NOT_CONFIGURED,
+  MISSING_DIRECTORY,
+  EMPTY_DIRECTORY,
+}
+
+class ContextValidationException(message: String) : IllegalArgumentException(message)
+
+object ContextLoader {
+
+  private val markdownExtensions = setOf("md", "markdown")
+  private val bundledCache: String by lazy { loadBundledFromClasspath() }
+
+  fun loadBundled(): String = bundledCache
+
+  private fun loadBundledFromClasspath(): String {
+    val resourceDir = "verity/context"
+    val files = listOf("maestro.md", "tv-controls.md")
+    return files.mapNotNull { filename ->
+      ContextLoader::class.java.classLoader
+        ?.getResourceAsStream("$resourceDir/$filename")
+        ?.bufferedReader()
+        ?.use { it.readText().trim() }
+    }.joinToString("\n\n")
+  }
+
+  fun load(directory: File): String = loadProject(directory = directory, required = false).text
+
+  fun loadProject(directory: File?, required: Boolean): ContextBundle {
+    val bundle = when {
+      directory == null -> ContextBundle(
+        text = "",
+        loadedFiles = emptyList(),
+        status = ContextStatus.NOT_CONFIGURED,
+      )
+
+      !directory.isDirectory -> ContextBundle(
+        text = "",
+        loadedFiles = emptyList(),
+        status = ContextStatus.MISSING_DIRECTORY,
+      )
+
+      else -> {
+        val files = directory.listFiles()
+          ?.filter { it.isFile && it.extension in markdownExtensions }
+          ?.sortedBy { it.name }
+          ?: emptyList()
+
+        if (files.isEmpty()) {
+          ContextBundle(
+            text = "",
+            loadedFiles = emptyList(),
+            status = ContextStatus.EMPTY_DIRECTORY,
+          )
+        } else {
+          ContextBundle(
+            text = files.joinToString("\n\n") { it.readText().trim() },
+            loadedFiles = files,
+            status = ContextStatus.LOADED,
+          )
+        }
+      }
+    }
+
+    if (required && bundle.status != ContextStatus.LOADED) {
+      throw ContextValidationException(bundle.requiredFailureMessage(directory))
+    }
+
+    return bundle
+  }
+
+  private fun ContextBundle.requiredFailureMessage(directory: File?): String = when (status) {
+    ContextStatus.LOADED -> error("Loaded context is not a validation failure")
+    ContextStatus.NOT_CONFIGURED ->
+      "Required project context is not configured. Set --context-path before using --require-context."
+
+    ContextStatus.MISSING_DIRECTORY ->
+      "Required project context directory does not exist or is not a directory: ${directory!!.absolutePath}"
+
+    ContextStatus.EMPTY_DIRECTORY ->
+      "Required project context directory contains no markdown files: ${directory!!.absolutePath}"
+  }
+}
+```
+
+- [ ] **Step 5: Run the core context tests and verify they pass**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:core:test --tests me.chrisbanes.verity.core.context.ContextLoaderTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit core context validation**
+
+Run:
+
+```bash
+rtk git add verity/core/src/main/kotlin/me/chrisbanes/verity/core/context/ContextLoader.kt verity/core/src/test/kotlin/me/chrisbanes/verity/core/context/ContextLoaderTest.kt
+rtk git commit -m "feat: add project context validation"
+```
+
+---
+
+### Task 2: CLI Required-Context Configuration
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/VerityConfig.kt`
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/Verity.kt`
+- Test: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityConfigTest.kt`
+- Test: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityTest.kt`
+
+- [ ] **Step 1: Write failing config tests**
+
+Add these tests to `VerityConfigTest`:
+
+```kotlin
+@Test
+fun `parses require context config`() {
+  val yaml =
+    """
+    require-context: true
+    """.trimIndent()
+
+  val config = VerityConfig.fromYaml(yaml)
+
+  assertThat(config.requireContext).isEqualTo(true)
+}
+
+@Test
+fun `resolveRequiredContext uses cli flag before config`() {
+  assertThat(resolveRequiredContext(cliRequireContext = true, config = VerityConfig(requireContext = false)))
+    .isEqualTo(true)
+}
+
+@Test
+fun `resolveRequiredContext uses config when cli flag is false`() {
+  assertThat(resolveRequiredContext(cliRequireContext = false, config = VerityConfig(requireContext = true)))
+    .isEqualTo(true)
+}
+
+@Test
+fun `resolveRequiredContext defaults to false`() {
+  assertThat(resolveRequiredContext(cliRequireContext = false, config = VerityConfig()))
+    .isEqualTo(false)
+}
+```
+
+- [ ] **Step 2: Write failing help test**
+
+Add this assertion to `prints help message` in `VerityTest`:
+
+```kotlin
+assertThat(result.output).contains("--require-context")
+```
+
+- [ ] **Step 3: Run CLI tests and verify they fail**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.VerityConfigTest --tests me.chrisbanes.verity.cli.VerityTest
+```
+
+Expected: FAIL because `requireContext`, `resolveRequiredContext`, and `--require-context` do not exist yet.
+
+- [ ] **Step 4: Implement config parsing and resolution**
+
+Change `VerityConfig` to:
+
+```kotlin
+@Serializable
+data class VerityConfig(
+  val provider: String? = null,
+  @SerialName("navigator-model") val navigatorModel: String? = null,
+  @SerialName("inspector-model") val inspectorModel: String? = null,
+  @SerialName("require-context") val requireContext: Boolean? = null,
+)
+```
+
+Add this helper to `VerityConfig.kt`:
+
+```kotlin
+fun resolveRequiredContext(cliRequireContext: Boolean, config: VerityConfig): Boolean =
+  cliRequireContext || config.requireContext == true
+```
+
+- [ ] **Step 5: Add the shared CLI flag**
+
+Add this property to `Verity` after `contextPath`:
+
+```kotlin
+val requireContext: Boolean by option(
+  "--require-context",
+  help = "Fail when project context is not configured or contains no markdown files",
+).flag()
+```
+
+- [ ] **Step 6: Run CLI config and help tests**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.VerityConfigTest --tests me.chrisbanes.verity.cli.VerityTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit CLI configuration**
+
+Run:
+
+```bash
+rtk git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/VerityConfig.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/Verity.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityConfigTest.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityTest.kt
+rtk git commit -m "feat: add required context configuration"
+```
+
+---
+
+### Task 3: CLI Run Validation and Reporting
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+- Modify: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt`
+
+- [ ] **Step 1: Write failing command test for required missing context**
+
+Add these imports to `RunCommandSmokeTest.kt`:
+
+```kotlin
+import assertk.assertions.contains
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.testing.test
+```
+
+Add this test:
+
+```kotlin
+@Test
+fun `run command fails before device connection when required context is missing`() {
+  val journeyUrl = javaClass.classLoader.getResource("smoke/minimal.journey.yaml")!!
+
+  val result = Verity()
+    .subcommands(RunCommand(), ListCommand(), McpCommand())
+    .test(
+      listOf(
+        "--provider",
+        "ollama",
+        "--context-path",
+        "/nonexistent/context",
+        "--require-context",
+        "run",
+        java.io.File(journeyUrl.toURI()).absolutePath,
+      ),
+    )
+
+  assertThat(result.statusCode).isEqualTo(1)
+  assertThat(result.output)
+    .contains("Required project context directory does not exist or is not a directory: /nonexistent/context")
+}
+```
+
+- [ ] **Step 2: Run the new command test and verify it fails**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandSmokeTest
+```
+
+Expected: FAIL because `RunCommand` still calls `ContextLoader.load(File)` and does not validate required context before connecting.
+
+- [ ] **Step 3: Add context validation helpers to `RunCommand.kt`**
+
+Add these imports:
+
+```kotlin
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import me.chrisbanes.verity.core.context.ContextBundle
+import me.chrisbanes.verity.core.context.ContextStatus
+import me.chrisbanes.verity.core.context.ContextValidationException
+```
+
+Add these private functions at file scope after the class:
+
+```kotlin
+private fun ContextBundle.describeForCli(contextDir: File?, required: Boolean): List<String> {
+  val mode = if (required) "required" else "optional"
+  return when (status) {
+    ContextStatus.LOADED -> listOf("Project context: loaded ${loadedFiles.size} file(s)") +
+      loadedFiles.map { "  - ${it.displayPath()}" }
+
+    ContextStatus.NOT_CONFIGURED -> listOf("Project context: $mode, not configured")
+
+    ContextStatus.MISSING_DIRECTORY -> listOf(
+      "Project context: $mode, missing directory: ${contextDir!!.absolutePath}",
+    )
+
+    ContextStatus.EMPTY_DIRECTORY -> listOf(
+      "Project context: $mode, no markdown files found in: ${contextDir!!.absolutePath}",
+    )
+  }
+}
+
+private fun File.displayPath(): String {
+  val current = File("").absoluteFile.toPath().normalize()
+  val target = absoluteFile.toPath().normalize()
+  return runCatching { current.relativize(target).toString() }
+    .getOrDefault(absolutePath)
+}
+```
+
+- [ ] **Step 4: Validate context before device and LLM setup**
+
+In `RunCommand.run`, after the journey metadata `echo` lines and before `DeviceSessionFactory.connect`, add:
+
+```kotlin
+val contextDir = parent.contextPath?.let { File(it) }
+val requireContext = resolveRequiredContext(parent.requireContext, config)
+val projectContext = try {
+  withContext(Dispatchers.IO) {
+    ContextLoader.loadProject(directory = contextDir, required = requireContext)
+  }
+} catch (e: ContextValidationException) {
+  throw CliktError(e.message ?: "Project context validation failed")
+}
+projectContext.describeForCli(contextDir, requireContext).forEach { echo(it) }
+```
+
+Then remove the later line inside `session.use`:
+
+```kotlin
+val injectedContext = parent.contextPath?.let { ContextLoader.load(File(it)) } ?: ""
+```
+
+Pass `projectContext.text` into `Orchestrator`:
+
+```kotlin
+context = projectContext.text,
+```
+
+- [ ] **Step 5: Run CLI smoke tests**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandSmokeTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit CLI run validation**
+
+Run:
+
+```bash
+rtk git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt
+rtk git commit -m "feat: validate context before cli runs"
+```
+
+---
+
+### Task 4: MCP Context Validation and Metadata
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/McpCommand.kt`
+- Modify: `verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt`
+- Test: `verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/VerityMcpServerTest.kt`
+
+- [ ] **Step 1: Write failing MCP tests**
+
+Add these imports to `VerityMcpServerTest.kt`:
+
+```kotlin
+import assertk.assertions.isTrue
+import java.io.File
+```
+
+Add these tests:
+
+```kotlin
+@Test
+fun `get_context reports optional missing configured path`() = runTest {
+  val server = VerityMcpServer(contextPath = File("/nonexistent/context")).create()
+  val tool = server.tools["get_context"]!!
+
+  val result = tool.handler.invoke(
+    StubClientConnection(),
+    CallToolRequest(CallToolRequestParams(name = "get_context")),
+  )
+
+  val text = (result.content.first() as TextContent).text
+  assertThat(result.isError).isIn(null, false)
+  assertThat(text).contains("Project context: optional, missing directory: /nonexistent/context")
+  assertThat(text).contains("Maestro")
+}
+
+@Test
+fun `get_context reports loaded project context files`() = runTest {
+  val dir = kotlin.io.path.createTempDirectory("mcp-context").toFile()
+  try {
+    File(dir, "app.md").writeText("# App context")
+    val server = VerityMcpServer(contextPath = dir).create()
+    val tool = server.tools["get_context"]!!
+
+    val result = tool.handler.invoke(
+      StubClientConnection(),
+      CallToolRequest(CallToolRequestParams(name = "get_context")),
+    )
+
+    val text = (result.content.first() as TextContent).text
+    assertThat(result.isError).isIn(null, false)
+    assertThat(text).contains("Project context: loaded 1 file(s)")
+    assertThat(text).contains("app.md")
+    assertThat(text).contains("# App context")
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+
+@Test
+fun `get_context errors when required configured path is missing`() = runTest {
+  val server = VerityMcpServer(
+    contextPath = File("/nonexistent/context"),
+    requireContext = true,
+  ).create()
+  val tool = server.tools["get_context"]!!
+
+  val result = tool.handler.invoke(
+    StubClientConnection(),
+    CallToolRequest(CallToolRequestParams(name = "get_context")),
+  )
+
+  val text = (result.content.first() as TextContent).text
+  assertThat(result.isError).isTrue()
+  assertThat(text)
+    .contains("Required project context directory does not exist or is not a directory: /nonexistent/context")
+}
+```
+
+- [ ] **Step 2: Run MCP tests and verify they fail**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:mcp:test --tests me.chrisbanes.verity.mcp.VerityMcpServerTest
+```
+
+Expected: FAIL because `VerityMcpServer` does not accept `requireContext` and `get_context` does not report metadata.
+
+- [ ] **Step 3: Pass required context from `mcp` command**
+
+In `McpCommand.run`, add config loading and required-context resolution:
+
+```kotlin
+val config = VerityConfig.loadOrDefault(File("verity/config.yaml"))
+val requireContext = resolveRequiredContext(parent.requireContext, config)
+```
+
+Pass it into the server:
+
+```kotlin
+val server = VerityMcpServer(
+  contextPath = contextDir,
+  skipBundledContext = parent.noBundledContext,
+  requireContext = requireContext,
+)
+```
+
+- [ ] **Step 4: Add MCP server constructor parameter and helpers**
+
+Add this constructor parameter to `VerityMcpServer`:
+
+```kotlin
+private val requireContext: Boolean = false,
+```
+
+Add imports:
+
+```kotlin
+import me.chrisbanes.verity.core.context.ContextBundle
+import me.chrisbanes.verity.core.context.ContextStatus
+import me.chrisbanes.verity.core.context.ContextValidationException
+```
+
+Add these helpers inside `VerityMcpServer`:
+
+```kotlin
+private fun ContextBundle.describeForMcp(contextDir: File?, required: Boolean): String {
+  val mode = if (required) "required" else "optional"
+  return when (status) {
+    ContextStatus.LOADED -> buildString {
+      appendLine("Project context: loaded ${loadedFiles.size} file(s)")
+      loadedFiles.forEach { appendLine("- ${it.absolutePath}") }
+    }.trim()
+
+    ContextStatus.NOT_CONFIGURED -> "Project context: $mode, not configured"
+
+    ContextStatus.MISSING_DIRECTORY ->
+      "Project context: $mode, missing directory: ${contextDir!!.absolutePath}"
+
+    ContextStatus.EMPTY_DIRECTORY ->
+      "Project context: $mode, no markdown files found in: ${contextDir!!.absolutePath}"
+  }
+}
+```
+
+- [ ] **Step 5: Update `get_context` to use `loadProject`**
+
+Replace the context loading block in `registerGetContext` with:
+
+```kotlin
+val pathArg = args.string("path")
+val contextDir = pathArg?.let { File(it) } ?: contextPath
+val projectContext = try {
+  withContext(Dispatchers.IO) {
+    ContextLoader.loadProject(directory = contextDir, required = requireContext)
+  }
+} catch (e: ContextValidationException) {
+  return@addSafeTool error(e.message ?: "Project context validation failed")
+}
+val bundled = if (skipBundledContext) "" else ContextLoader.loadBundled()
+val metadata = projectContext.describeForMcp(contextDir, requireContext)
+val content = listOf(metadata, bundled, projectContext.text)
+  .filter { it.isNotBlank() }
+  .joinToString("\n\n")
+
+if (content.isBlank()) {
+  error("No context path configured and no bundled defaults found.")
+} else {
+  success(content)
+}
+```
+
+This intentionally changes optional no-path behavior with bundled context from only bundled text to metadata plus bundled text.
+
+- [ ] **Step 6: Run MCP tests**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:mcp:test --tests me.chrisbanes.verity.mcp.VerityMcpServerTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit MCP validation**
+
+Run:
+
+```bash
+rtk git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/McpCommand.kt verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/VerityMcpServerTest.kt
+rtk git commit -m "feat: validate mcp project context"
+```
+
+---
+
+### Task 5: Architecture Documentation
+
+**Files:**
+- Modify: `docs/architecture.md`
+
+- [ ] **Step 1: Update CLI shared options**
+
+In `docs/architecture.md`, add this line to the shared options block after `--context-path <dir>`:
+
+```text
+--require-context      Fail if project context is missing or contains no markdown files
+```
+
+- [ ] **Step 2: Add config documentation**
+
+Near the CLI section, add:
+
+````markdown
+### Configuration
+
+`verity/config.yaml` can provide defaults for provider and model selection:
+
+```yaml
+provider: anthropic
+navigator-model: claude-haiku-4-5
+inspector-model: claude-opus-4-5
+require-context: true
+```
+
+`require-context` makes `--context-path` mandatory for workflows that depend on project context. A CLI `--require-context` flag also enables this behavior for one invocation.
+````
+
+- [ ] **Step 3: Document context validation in execution data flow**
+
+In the CLI Run flow, add context validation between journey loading and device connection:
+
+```text
+ContextLoader.loadProject()
+    |-- LOADED -> report loaded markdown files, inject text into NavigatorAgent
+    |-- NOT_CONFIGURED -> optional explicit status or required error
+    |-- MISSING_DIRECTORY -> optional explicit status or required error
+    `-- EMPTY_DIRECTORY -> optional explicit status or required error
+```
+
+- [ ] **Step 4: Update MCP `get_context` documentation**
+
+Update the MCP tool table row for `get_context` to describe:
+
+```markdown
+| `get_context` | optional path | loaded-file metadata + bundled defaults + markdown context text | Required context can error |
+```
+
+- [ ] **Step 5: Commit docs**
+
+Run:
+
+```bash
+rtk git add docs/architecture.md
+rtk git commit -m "docs: document project context validation"
+```
+
+---
+
+### Task 6: Formatting and Full Verification
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Apply formatting**
+
+Run:
+
+```bash
+rtk ./gradlew spotlessApply
+```
+
+Expected: SUCCESS. If files change, inspect `rtk git diff --stat` and commit the formatting changes with the relevant task commit if still uncommitted, or a final formatting commit if earlier commits already exist.
+
+- [ ] **Step 2: Run full check**
+
+Run:
+
+```bash
+rtk ./gradlew check
+```
+
+Expected: SUCCESS.
+
+- [ ] **Step 3: Check final git status**
+
+Run:
+
+```bash
+rtk git status --short --branch
+```
+
+Expected: branch `github-issue-47-fix` with no unstaged or uncommitted changes.
+
+- [ ] **Step 4: Final review**
+
+Inspect the final diff:
+
+```bash
+rtk git log --oneline -6
+rtk git diff HEAD~5..HEAD --stat
+```
+
+Expected: commits cover core validation, CLI config, CLI run validation, MCP validation, docs, and any formatting changes. No unrelated files are changed.

--- a/docs/superpowers/specs/2026-07-07-project-context-validation-design.md
+++ b/docs/superpowers/specs/2026-07-07-project-context-validation-design.md
@@ -1,0 +1,125 @@
+# Project Context Validation Design
+
+## Issue
+
+GitHub issue 47 asks Verity to validate project context before a run or MCP workflow depends on it. The current implementation loads optional markdown context through `ContextLoader`, but missing or malformed context directories collapse to an empty string. That makes configuration mistakes hard to distinguish from intentionally omitted optional context.
+
+## Goals
+
+- Validate configured project context directories before they are used.
+- Report which project context files were loaded.
+- Support required project context from both CLI flags and `verity/config.yaml`.
+- Preserve optional context behavior when context is not required.
+- Cover validation behavior with focused tests.
+
+## Non-Goals
+
+- Change bundled context loading semantics.
+- Add non-markdown project context formats.
+- Change the generated prompt structure beyond adding context metadata to user-visible output.
+- Introduce a new config file location.
+
+## Required Context Resolution
+
+Required context is a resolved setting with this precedence:
+
+1. CLI flag: `--require-context`
+2. Config file: `require-context: true`
+3. Default: `false`
+
+The CLI flag only enables required context. There is no negative flag in this design. If `verity/config.yaml` sets `require-context: true`, a caller must remove or change that config value to make context optional.
+
+## Core Contract
+
+Add a structured project-context result in `:verity:core`, owned by the existing context package:
+
+```kotlin
+data class ContextBundle(
+  val text: String,
+  val loadedFiles: List<File>,
+  val status: ContextStatus,
+)
+
+enum class ContextStatus {
+  LOADED,
+  NOT_CONFIGURED,
+  MISSING_DIRECTORY,
+  EMPTY_DIRECTORY,
+}
+```
+
+Add a new `ContextLoader.loadProject(directory: File?, required: Boolean): ContextBundle` API.
+
+Behavior:
+
+- `directory == null` returns `NOT_CONFIGURED` when optional.
+- A non-existent path or non-directory path returns `MISSING_DIRECTORY` when optional.
+- A valid directory with no `.md` or `.markdown` files returns `EMPTY_DIRECTORY` when optional.
+- A valid directory with markdown files returns `LOADED`, sorted by file name, with concatenated trimmed content and the loaded file list.
+- When `required` is true, all non-`LOADED` statuses throw a typed `ContextValidationException` with a clear, user-facing message.
+
+The existing `ContextLoader.load(File): String` can remain temporarily as a compatibility wrapper around the new API because the repository currently has few call sites.
+
+## CLI Behavior
+
+Add shared `--require-context` support to `Verity` and add `@SerialName("require-context") val requireContext: Boolean? = null` to `VerityConfig`.
+
+`verity run` validates project context after config and journey resolution but before device connection and LLM setup. This keeps failures fast and avoids touching external systems when the run cannot proceed.
+
+Run output should explicitly report project context state:
+
+- `Project context: optional, not configured`
+- `Project context: optional, missing directory: <path>`
+- `Project context: optional, no markdown files found in: <path>`
+- `Project context: loaded N file(s)`
+
+When files are loaded, print each loaded path in deterministic order. Prefer paths relative to the working directory when possible; otherwise print absolute paths.
+
+When required context is missing, malformed, or empty, fail with the `ContextValidationException` message before opening a device session.
+
+## MCP Behavior
+
+Pass the resolved required-context setting into `VerityMcpServer`.
+
+`get_context` continues to return bundled defaults plus optional project context. Its response should also include loaded project-context file metadata before the combined context text. Optional missing context remains non-fatal and explicit. Required missing context returns a tool error with the same clear validation message used by the CLI.
+
+The `get_context` `path` argument remains supported. If supplied, it is validated using the same required/optional setting as the server-level context path.
+
+## Tests
+
+Core tests:
+
+- Optional `null` directory returns `NOT_CONFIGURED`.
+- Optional missing/non-directory path returns `MISSING_DIRECTORY`.
+- Optional empty directory returns `EMPTY_DIRECTORY`.
+- Required missing, non-directory, and empty directory throw clear validation errors.
+- Markdown and `.markdown` files load in deterministic order and report loaded files.
+- Non-markdown files remain ignored.
+
+CLI tests:
+
+- `VerityConfig` parses `require-context`.
+- Help output includes `--require-context`.
+- Required context failure occurs before device connection where practical to test.
+
+MCP tests:
+
+- `get_context` reports bundled defaults when no path is configured and context is optional.
+- `get_context` reports loaded project files when context exists.
+- `get_context` returns explicit optional missing context when optional.
+- `get_context` returns an error when context is required and missing.
+
+## Documentation
+
+Update `docs/architecture.md` to document:
+
+- `--require-context`
+- `require-context` config
+- project context validation statuses
+- `get_context` loaded-file reporting
+
+## Implementation Notes
+
+Blocking file I/O should be wrapped in `Dispatchers.IO` at CLI and MCP call sites. The core loader can stay synchronous, matching its current shape.
+
+Use assertk in tests. Run `./gradlew spotlessApply` before final verification, then `./gradlew check`.

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/McpCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/McpCommand.kt
@@ -22,11 +22,14 @@ class McpCommand : CliktCommand(name = "mcp") {
 
   override fun run() = runBlocking {
     val parent = currentContext.parent?.command as Verity
+    val config = VerityConfig.loadOrDefault(File("verity/config.yaml"))
     val contextDir = parent.contextPath?.let { File(it) }
+    val requireContext = resolveRequiredContext(parent.requireContext, config)
 
     val server = VerityMcpServer(
       contextPath = contextDir,
       skipBundledContext = parent.noBundledContext,
+      requireContext = requireContext,
     )
 
     when (transport) {

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -10,12 +10,17 @@ import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import java.io.File
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import me.chrisbanes.verity.agent.InspectorAgent
 import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.NavigatorAgent
 import me.chrisbanes.verity.agent.Orchestrator
+import me.chrisbanes.verity.core.context.ContextBundle
 import me.chrisbanes.verity.core.context.ContextLoader
+import me.chrisbanes.verity.core.context.ContextStatus
+import me.chrisbanes.verity.core.context.ContextValidationException
 import me.chrisbanes.verity.core.journey.JourneyLoader
 import me.chrisbanes.verity.core.model.Journey
 import me.chrisbanes.verity.device.DeviceSessionFactory
@@ -132,6 +137,15 @@ class RunCommand(
     val config = VerityConfig.loadOrDefault(File("verity/config.yaml"))
     val firstJourney = journeys.first().journey
     val platform = parent.platform ?: firstJourney.platform
+    val contextDir = parent.contextPath?.let { File(it) }
+    val requireContext = resolveRequiredContext(parent.requireContext, config)
+    val projectContext = try {
+      withContext(Dispatchers.IO) {
+        ContextLoader.loadProject(directory = contextDir, required = requireContext)
+      }
+    } catch (e: ContextValidationException) {
+      throw CliktError(e.message ?: "Project context validation failed")
+    }
 
     val preflight = CliPreflightChecker().check(
       request = CliPreflightRequest(
@@ -140,7 +154,7 @@ class RunCommand(
         cliInspectorModel = parent.inspectorModel,
         apiKey = parent.apiKey,
         journeyPath = journeyPath,
-        contextPath = parent.contextPath,
+        contextPath = null,
         platform = platform,
         deviceId = parent.device,
       ),
@@ -157,6 +171,7 @@ class RunCommand(
     echo("Provider: ${provider.name}")
     echo("Navigator model: ${navigatorModel.id}")
     echo("Inspector model: ${inspectorModel.id}")
+    projectContext.describeForCli(contextDir, requireContext).forEach { echo(it) }
 
     val session = DeviceSessionFactory.connect(
       platform = platform,
@@ -167,8 +182,6 @@ class RunCommand(
     val executor = SingleLLMPromptExecutor(provider.createClient(apiKey))
 
     session.use {
-      val injectedContext = parent.contextPath?.let { ContextLoader.load(File(it)) } ?: ""
-
       val orchestrator = Orchestrator(
         session = session,
         navigatorFactory = {
@@ -205,7 +218,7 @@ class RunCommand(
             },
           )
         },
-        context = injectedContext,
+        context = projectContext.text,
       )
 
       return SuiteRunResult(
@@ -218,4 +231,29 @@ class RunCommand(
       )
     }
   }
+}
+
+private fun ContextBundle.describeForCli(contextDir: File?, required: Boolean): List<String> {
+  val mode = if (required) "required" else "optional"
+  return when (status) {
+    ContextStatus.LOADED -> listOf("Project context: loaded ${loadedFiles.size} file(s)") +
+      loadedFiles.map { "  - ${it.displayPath()}" }
+
+    ContextStatus.NOT_CONFIGURED -> listOf("Project context: $mode, not configured")
+
+    ContextStatus.MISSING_DIRECTORY -> listOf(
+      "Project context: $mode, missing directory: ${contextDir!!.absolutePath}",
+    )
+
+    ContextStatus.EMPTY_DIRECTORY -> listOf(
+      "Project context: $mode, no markdown files found in: ${contextDir!!.absolutePath}",
+    )
+  }
+}
+
+private fun File.displayPath(): String {
+  val current = File("").absoluteFile.toPath().normalize()
+  val target = absoluteFile.toPath().normalize()
+  return runCatching { current.relativize(target).toString() }
+    .getOrDefault(absolutePath)
 }

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/Verity.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/Verity.kt
@@ -23,6 +23,10 @@ class Verity : CliktCommand(name = "verity") {
     "--context-path",
     help = "Optional path to additional context markdown files",
   )
+  val requireContext: Boolean by option(
+    "--require-context",
+    help = "Fail when project context is not configured or contains no markdown files",
+  ).flag()
   val noAnimations: Boolean by option("--no-animations", help = "Disable device animations")
     .flag()
   val noBundledContext: Boolean by option(

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/VerityConfig.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/VerityConfig.kt
@@ -11,6 +11,7 @@ data class VerityConfig(
   val provider: String? = null,
   @SerialName("navigator-model") val navigatorModel: String? = null,
   @SerialName("inspector-model") val inspectorModel: String? = null,
+  @SerialName("require-context") val requireContext: Boolean? = null,
 ) {
   companion object {
     fun fromYaml(yaml: String): VerityConfig = Yaml.default.decodeFromString(serializer(), yaml)
@@ -22,6 +23,9 @@ data class VerityConfig(
     }
   }
 }
+
+fun resolveRequiredContext(cliRequireContext: Boolean, config: VerityConfig): Boolean =
+  cliRequireContext || config.requireContext == true
 
 fun resolveProvider(cliProvider: String?, config: VerityConfig): VerityProvider {
   val name = cliProvider ?: config.provider ?: "anthropic"

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/VerityConfig.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/VerityConfig.kt
@@ -24,8 +24,7 @@ data class VerityConfig(
   }
 }
 
-fun resolveRequiredContext(cliRequireContext: Boolean, config: VerityConfig): Boolean =
-  cliRequireContext || config.requireContext == true
+fun resolveRequiredContext(cliRequireContext: Boolean, config: VerityConfig): Boolean = cliRequireContext || config.requireContext == true
 
 fun resolveProvider(cliProvider: String?, config: VerityConfig): VerityProvider {
   val name = cliProvider ?: config.provider ?: "anthropic"

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt
@@ -1,9 +1,12 @@
 package me.chrisbanes.verity.cli
 
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.testing.test
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 import me.chrisbanes.verity.agent.FakeTextAgent
@@ -16,6 +19,29 @@ import me.chrisbanes.verity.core.model.Platform
 import me.chrisbanes.verity.device.FakeDeviceSession
 
 class RunCommandSmokeTest {
+
+  @Test
+  fun `run command fails before device connection when required context is missing`() {
+    val journeyUrl = javaClass.classLoader.getResource("smoke/minimal.journey.yaml")!!
+
+    val result = Verity()
+      .subcommands(RunCommand(), ListCommand(), McpCommand())
+      .test(
+        listOf(
+          "--provider",
+          "ollama",
+          "--context-path",
+          "/nonexistent/context",
+          "--require-context",
+          "run",
+          java.io.File(journeyUrl.toURI()).absolutePath,
+        ),
+      )
+
+    assertThat(result.statusCode).isEqualTo(1)
+    assertThat(result.output)
+      .contains("Required project context directory does not exist or is not a directory: /nonexistent/context")
+  }
 
   @Test
   fun `smoke journey loads and passes with visible text`() = runTest {

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityConfigTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityConfigTest.kt
@@ -13,11 +13,13 @@ class VerityConfigTest {
       provider: openai
       navigator-model: gpt-4o-mini
       inspector-model: gpt-4o
+      require-context: true
       """.trimIndent()
     val config = VerityConfig.fromYaml(yaml)
     assertThat(config.provider).isEqualTo("openai")
     assertThat(config.navigatorModel).isEqualTo("gpt-4o-mini")
     assertThat(config.inspectorModel).isEqualTo("gpt-4o")
+    assertThat(config.requireContext).isEqualTo(true)
   }
 
   @Test
@@ -27,6 +29,7 @@ class VerityConfigTest {
     assertThat(config.provider).isEqualTo("google")
     assertThat(config.navigatorModel).isNull()
     assertThat(config.inspectorModel).isNull()
+    assertThat(config.requireContext).isNull()
   }
 
   @Test
@@ -35,6 +38,7 @@ class VerityConfigTest {
     assertThat(config.provider).isNull()
     assertThat(config.navigatorModel).isNull()
     assertThat(config.inspectorModel).isNull()
+    assertThat(config.requireContext).isNull()
   }
 
   @Test
@@ -53,5 +57,35 @@ class VerityConfigTest {
     } finally {
       tempFile.delete()
     }
+  }
+
+  @Test
+  fun `parses require context config`() {
+    val yaml =
+      """
+      require-context: true
+      """.trimIndent()
+
+    val config = VerityConfig.fromYaml(yaml)
+
+    assertThat(config.requireContext).isEqualTo(true)
+  }
+
+  @Test
+  fun `resolveRequiredContext uses cli flag before config`() {
+    assertThat(resolveRequiredContext(cliRequireContext = true, config = VerityConfig(requireContext = false)))
+      .isEqualTo(true)
+  }
+
+  @Test
+  fun `resolveRequiredContext uses config when cli flag is false`() {
+    assertThat(resolveRequiredContext(cliRequireContext = false, config = VerityConfig(requireContext = true)))
+      .isEqualTo(true)
+  }
+
+  @Test
+  fun `resolveRequiredContext defaults to false`() {
+    assertThat(resolveRequiredContext(cliRequireContext = false, config = VerityConfig()))
+      .isEqualTo(false)
   }
 }

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/VerityTest.kt
@@ -19,6 +19,7 @@ class VerityTest {
     assertThat(result.output).contains("--provider")
     assertThat(result.output).contains("--navigator-model")
     assertThat(result.output).contains("--inspector-model")
+    assertThat(result.output).contains("--require-context")
   }
 
   @Test

--- a/verity/core/src/main/kotlin/me/chrisbanes/verity/core/context/ContextLoader.kt
+++ b/verity/core/src/main/kotlin/me/chrisbanes/verity/core/context/ContextLoader.kt
@@ -82,6 +82,7 @@ object ContextLoader {
 
   private fun ContextBundle.requiredFailureMessage(directory: File?): String = when (status) {
     ContextStatus.LOADED -> error("Loaded context is not a validation failure")
+
     ContextStatus.NOT_CONFIGURED ->
       "Required project context is not configured. Set --context-path before using --require-context."
 

--- a/verity/core/src/main/kotlin/me/chrisbanes/verity/core/context/ContextLoader.kt
+++ b/verity/core/src/main/kotlin/me/chrisbanes/verity/core/context/ContextLoader.kt
@@ -2,8 +2,24 @@ package me.chrisbanes.verity.core.context
 
 import java.io.File
 
+data class ContextBundle(
+  val text: String,
+  val loadedFiles: List<File>,
+  val status: ContextStatus,
+)
+
+enum class ContextStatus {
+  LOADED,
+  NOT_CONFIGURED,
+  MISSING_DIRECTORY,
+  EMPTY_DIRECTORY,
+}
+
+class ContextValidationException(message: String) : IllegalArgumentException(message)
+
 object ContextLoader {
 
+  private val markdownExtensions = setOf("md", "markdown")
   private val bundledCache: String by lazy { loadBundledFromClasspath() }
 
   fun loadBundled(): String = bundledCache
@@ -19,13 +35,60 @@ object ContextLoader {
     }.joinToString("\n\n")
   }
 
-  fun load(directory: File): String {
-    if (!directory.isDirectory) return ""
+  fun load(directory: File): String = loadProject(directory = directory, required = false).text
 
-    return directory.listFiles()
-      ?.filter { it.isFile && it.extension in setOf("md", "markdown") }
-      ?.sortedBy { it.name }
-      ?.joinToString("\n\n") { it.readText().trim() }
-      ?: ""
+  fun loadProject(directory: File?, required: Boolean): ContextBundle {
+    val bundle = when {
+      directory == null -> ContextBundle(
+        text = "",
+        loadedFiles = emptyList(),
+        status = ContextStatus.NOT_CONFIGURED,
+      )
+
+      !directory.isDirectory -> ContextBundle(
+        text = "",
+        loadedFiles = emptyList(),
+        status = ContextStatus.MISSING_DIRECTORY,
+      )
+
+      else -> {
+        val files = directory.listFiles()
+          ?.filter { it.isFile && it.extension in markdownExtensions }
+          ?.sortedBy { it.name }
+          ?: emptyList()
+
+        if (files.isEmpty()) {
+          ContextBundle(
+            text = "",
+            loadedFiles = emptyList(),
+            status = ContextStatus.EMPTY_DIRECTORY,
+          )
+        } else {
+          ContextBundle(
+            text = files.joinToString("\n\n") { it.readText().trim() },
+            loadedFiles = files,
+            status = ContextStatus.LOADED,
+          )
+        }
+      }
+    }
+
+    if (required && bundle.status != ContextStatus.LOADED) {
+      throw ContextValidationException(bundle.requiredFailureMessage(directory))
+    }
+
+    return bundle
+  }
+
+  private fun ContextBundle.requiredFailureMessage(directory: File?): String = when (status) {
+    ContextStatus.LOADED -> error("Loaded context is not a validation failure")
+    ContextStatus.NOT_CONFIGURED ->
+      "Required project context is not configured. Set --context-path before using --require-context."
+
+    ContextStatus.MISSING_DIRECTORY ->
+      "Required project context directory does not exist or is not a directory: ${directory!!.absolutePath}"
+
+    ContextStatus.EMPTY_DIRECTORY ->
+      "Required project context directory contains no markdown files: ${directory!!.absolutePath}"
   }
 }

--- a/verity/core/src/test/kotlin/me/chrisbanes/verity/core/context/ContextLoaderTest.kt
+++ b/verity/core/src/test/kotlin/me/chrisbanes/verity/core/context/ContextLoaderTest.kt
@@ -1,7 +1,7 @@
 package me.chrisbanes.verity.core.context
 
-import assertk.assertThat
 import assertk.assertFailure
+import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.containsExactly
 import assertk.assertions.hasMessage

--- a/verity/core/src/test/kotlin/me/chrisbanes/verity/core/context/ContextLoaderTest.kt
+++ b/verity/core/src/test/kotlin/me/chrisbanes/verity/core/context/ContextLoaderTest.kt
@@ -1,8 +1,12 @@
 package me.chrisbanes.verity.core.context
 
 import assertk.assertThat
+import assertk.assertFailure
 import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
 import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotEmpty
 import java.io.File
@@ -65,6 +69,92 @@ class ContextLoaderTest {
       val context = ContextLoader.load(dir)
       assertThat(context).contains("# App context")
       assertThat(context).contains("# Extra context")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `loadProject returns not configured for optional null directory`() {
+    val bundle = ContextLoader.loadProject(directory = null, required = false)
+
+    assertThat(bundle.status).isEqualTo(ContextStatus.NOT_CONFIGURED)
+    assertThat(bundle.text).isEmpty()
+    assertThat(bundle.loadedFiles).isEmpty()
+  }
+
+  @Test
+  fun `loadProject returns missing directory for optional nonexistent path`() {
+    val directory = File("/nonexistent/path")
+
+    val bundle = ContextLoader.loadProject(directory = directory, required = false)
+
+    assertThat(bundle.status).isEqualTo(ContextStatus.MISSING_DIRECTORY)
+    assertThat(bundle.text).isEmpty()
+    assertThat(bundle.loadedFiles).isEmpty()
+  }
+
+  @Test
+  fun `loadProject returns empty directory for optional directory without markdown files`() {
+    val dir = kotlin.io.path.createTempDirectory("empty-context").toFile()
+    try {
+      File(dir, "notes.txt").writeText("ignored")
+
+      val bundle = ContextLoader.loadProject(directory = dir, required = false)
+
+      assertThat(bundle.status).isEqualTo(ContextStatus.EMPTY_DIRECTORY)
+      assertThat(bundle.text).isEmpty()
+      assertThat(bundle.loadedFiles).isEmpty()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `loadProject reports loaded markdown files in deterministic order`() {
+    val dir = createTempContextDir(
+      "b.markdown" to "Section B",
+      "a.md" to "Section A",
+      "notes.txt" to "ignored",
+    )
+    try {
+      val bundle = ContextLoader.loadProject(directory = dir, required = true)
+
+      assertThat(bundle.status).isEqualTo(ContextStatus.LOADED)
+      assertThat(bundle.text).isEqualTo("Section A\n\nSection B")
+      assertThat(bundle.loadedFiles.map { it.name }).containsExactly("a.md", "b.markdown")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `loadProject throws clear error when required context is not configured`() {
+    assertFailure {
+      ContextLoader.loadProject(directory = null, required = true)
+    }.hasMessage("Required project context is not configured. Set --context-path before using --require-context.")
+  }
+
+  @Test
+  fun `loadProject throws clear error when required context directory is missing`() {
+    val directory = File("/nonexistent/path")
+
+    assertFailure {
+      ContextLoader.loadProject(directory = directory, required = true)
+    }.hasMessage(
+      "Required project context directory does not exist or is not a directory: ${directory.absolutePath}",
+    )
+  }
+
+  @Test
+  fun `loadProject throws clear error when required context directory is empty`() {
+    val dir = kotlin.io.path.createTempDirectory("required-empty-context").toFile()
+    try {
+      assertFailure {
+        ContextLoader.loadProject(directory = dir, required = true)
+      }.hasMessage(
+        "Required project context directory contains no markdown files: ${dir.absolutePath}",
+      )
     } finally {
       dir.deleteRecursively()
     }

--- a/verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt
+++ b/verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt
@@ -564,13 +564,16 @@ class VerityMcpServer(
       }
       val bundled = if (skipBundledContext) "" else ContextLoader.loadBundled()
       val metadata = projectContext.describeForMcp(contextDir, requireContext)
-      val content = listOf(metadata, bundled, projectContext.text)
+      val usableContext = listOf(bundled, projectContext.text)
         .filter { it.isNotBlank() }
         .joinToString("\n\n")
 
-      if (content.isBlank()) {
+      if (usableContext.isBlank()) {
         error("No context path configured and no bundled defaults found.")
       } else {
+        val content = listOf(metadata, usableContext)
+          .filter { it.isNotBlank() }
+          .joinToString("\n\n")
         success(content)
       }
     }

--- a/verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt
+++ b/verity/mcp/src/main/kotlin/me/chrisbanes/verity/mcp/VerityMcpServer.kt
@@ -36,7 +36,10 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
+import me.chrisbanes.verity.core.context.ContextBundle
 import me.chrisbanes.verity.core.context.ContextLoader
+import me.chrisbanes.verity.core.context.ContextStatus
+import me.chrisbanes.verity.core.context.ContextValidationException
 import me.chrisbanes.verity.core.hierarchy.HierarchyFilter
 import me.chrisbanes.verity.core.hierarchy.HierarchyRenderer
 import me.chrisbanes.verity.core.journey.JourneyLoader
@@ -54,6 +57,7 @@ class VerityMcpServer(
   private val skipBundledContext: Boolean = false,
   private val devicePreflightChecker: DevicePreflightChecker = PlatformDevicePreflightChecker(),
   private val pathPreflightChecker: PathPreflightChecker = PathPreflightChecker(),
+  private val requireContext: Boolean = false,
 ) {
 
   fun create(): Server {
@@ -550,35 +554,43 @@ class VerityMcpServer(
       ),
     ) { args ->
       val pathArg = args.string("path")
-      val contextDir = when {
-        pathArg != null -> File(pathArg)
-
-        contextPath != null -> contextPath
-
-        else -> {
-          if (skipBundledContext) {
-            return@addSafeTool error(
-              "No context path configured. Use the 'path' parameter or start the server with --context-path.",
-            )
-          }
-          val bundled = ContextLoader.loadBundled()
-          return@addSafeTool if (bundled.isNotBlank()) {
-            success(bundled)
-          } else {
-            error("No context path configured and no bundled defaults found.")
-          }
+      val contextDir = pathArg?.let { File(it) } ?: contextPath
+      val projectContext = try {
+        withContext(Dispatchers.IO) {
+          ContextLoader.loadProject(directory = contextDir, required = requireContext)
         }
-      }
-      val appContext = withContext(Dispatchers.IO) {
-        ContextLoader.load(contextDir)
+      } catch (e: ContextValidationException) {
+        return@addSafeTool error(e.message ?: "Project context validation failed")
       }
       val bundled = if (skipBundledContext) "" else ContextLoader.loadBundled()
-      val combined = listOf(bundled, appContext).filter { it.isNotBlank() }.joinToString("\n\n")
-      if (combined.isBlank()) {
-        success("No context files found in: ${contextDir.absolutePath}")
+      val metadata = projectContext.describeForMcp(contextDir, requireContext)
+      val content = listOf(metadata, bundled, projectContext.text)
+        .filter { it.isNotBlank() }
+        .joinToString("\n\n")
+
+      if (content.isBlank()) {
+        error("No context path configured and no bundled defaults found.")
       } else {
-        success(combined)
+        success(content)
       }
+    }
+  }
+
+  private fun ContextBundle.describeForMcp(contextDir: File?, required: Boolean): String {
+    val mode = if (required) "required" else "optional"
+    return when (status) {
+      ContextStatus.LOADED -> buildString {
+        appendLine("Project context: loaded ${loadedFiles.size} file(s)")
+        loadedFiles.forEach { appendLine("- ${it.absolutePath}") }
+      }.trim()
+
+      ContextStatus.NOT_CONFIGURED -> "Project context: $mode, not configured"
+
+      ContextStatus.MISSING_DIRECTORY ->
+        "Project context: $mode, missing directory: ${contextDir!!.absolutePath}"
+
+      ContextStatus.EMPTY_DIRECTORY ->
+        "Project context: $mode, no markdown files found in: ${contextDir!!.absolutePath}"
     }
   }
 

--- a/verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/VerityMcpServerTest.kt
+++ b/verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/VerityMcpServerTest.kt
@@ -165,6 +165,21 @@ class VerityMcpServerTest {
   }
 
   @Test
+  fun `get_context errors when bundled and project context are absent`() = runTest {
+    val server = VerityMcpServer(skipBundledContext = true).create()
+    val tool = server.tools["get_context"]!!
+
+    val result = tool.handler.invoke(
+      StubClientConnection(),
+      CallToolRequest(CallToolRequestParams(name = "get_context")),
+    )
+
+    val text = (result.content.first() as TextContent).text
+    assertThat(result.isError).isEqualTo(true)
+    assertThat(text).contains("No context path configured and no bundled defaults found.")
+  }
+
+  @Test
   fun `get_context reports loaded project context files`() = runTest {
     val dir = kotlin.io.path.createTempDirectory("mcp-context").toFile()
     try {

--- a/verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/VerityMcpServerTest.kt
+++ b/verity/mcp/src/test/kotlin/me/chrisbanes/verity/mcp/VerityMcpServerTest.kt
@@ -11,6 +11,7 @@ import assertk.assertions.isNotNull
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import java.io.File
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
@@ -145,5 +146,63 @@ class VerityMcpServerTest {
 
     assertThat(result.isError).isEqualTo(true)
     assertThat(text).contains("path.not_writable")
+  }
+
+  @Test
+  fun `get_context reports optional missing configured path`() = runTest {
+    val server = VerityMcpServer(contextPath = File("/nonexistent/context")).create()
+    val tool = server.tools["get_context"]!!
+
+    val result = tool.handler.invoke(
+      StubClientConnection(),
+      CallToolRequest(CallToolRequestParams(name = "get_context")),
+    )
+
+    val text = (result.content.first() as TextContent).text
+    assertThat(result.isError).isIn(null, false)
+    assertThat(text).contains("Project context: optional, missing directory: /nonexistent/context")
+    assertThat(text).contains("Maestro")
+  }
+
+  @Test
+  fun `get_context reports loaded project context files`() = runTest {
+    val dir = kotlin.io.path.createTempDirectory("mcp-context").toFile()
+    try {
+      File(dir, "app.md").writeText("# App context")
+      val server = VerityMcpServer(contextPath = dir).create()
+      val tool = server.tools["get_context"]!!
+
+      val result = tool.handler.invoke(
+        StubClientConnection(),
+        CallToolRequest(CallToolRequestParams(name = "get_context")),
+      )
+
+      val text = (result.content.first() as TextContent).text
+      assertThat(result.isError).isIn(null, false)
+      assertThat(text).contains("Project context: loaded 1 file(s)")
+      assertThat(text).contains("app.md")
+      assertThat(text).contains("# App context")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `get_context errors when required configured path is missing`() = runTest {
+    val server = VerityMcpServer(
+      contextPath = File("/nonexistent/context"),
+      requireContext = true,
+    ).create()
+    val tool = server.tools["get_context"]!!
+
+    val result = tool.handler.invoke(
+      StubClientConnection(),
+      CallToolRequest(CallToolRequestParams(name = "get_context")),
+    )
+
+    val text = (result.content.first() as TextContent).text
+    assertThat(result.isError).isEqualTo(true)
+    assertThat(text)
+      .contains("Required project context directory does not exist or is not a directory: /nonexistent/context")
   }
 }


### PR DESCRIPTION
## Summary
- Add structured project-context validation with loaded-file metadata and clear required-context errors.
- Support `--require-context` and `require-context` in `verity/config.yaml`.
- Report project context status in CLI runs and MCP `get_context`, with architecture docs and tests updated.

## Validation
- `./gradlew check`

Closes #47