### PR TITLE
Persist suite artifacts and CI results

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -431,6 +431,12 @@ Each run contains:
 - `flows/<index>-<journey>/...` — Generated Maestro YAML when a segment used LLM flow generation.
 - `evidence/<index>-<journey>/...` — Hierarchy text and screenshots captured for assertions.
 
+Module ownership is split by artifact responsibility:
+
+- `:verity:core` owns the serializable artifact/result DTOs and stable wire values.
+- `:verity:agent` owns segment metadata collection and recorder calls for generated flows and evidence.
+- `:verity:cli` owns run directory layout, JSON writing, summary aggregation, and exit-code mapping.
+
 Exit codes are intentionally stable for CI:
 
 | Code | Classification | Summary error kind |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -422,7 +422,7 @@ require-context: true
 
 ### Run Artifacts And CI Results
 
-`verity run` writes one timestamped artifact directory under `paths.output/runs/` for every invocation after configuration resolution. The directory name is stable and slugged from the input suite, for example `20260708-143512-login-suite`.
+`verity run` writes one timestamped artifact directory under `paths.output/runs/` after configuration resolution and output-path validation. The directory name is stable and slugged from the input suite, for example `20260708-143512-login-suite`.
 
 Each run contains:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -420,6 +420,28 @@ require-context: true
 
 `require-context` makes `--context-path` mandatory for workflows that depend on project context. The CLI `--require-context` flag also enables this behavior for one invocation.
 
+### Run Artifacts And CI Results
+
+`verity run` writes one timestamped artifact directory under `paths.output/runs/` for every invocation after configuration resolution. The directory name is stable and slugged from the input suite, for example `20260708-143512-login-suite`.
+
+Each run contains:
+
+- `summary.json` — Suite-level CI contract with `formatVersion`, timestamp, input path, pass/fail counts, per-journey result references, error classification, platform, provider, navigator model, and inspector model.
+- `journeys/<index>-<journey>.json` — Journey-level result with identity, pass/fail state, failed segment index, segment execution mode, generated flow references, evidence references, assertions, reasoning, and optional diagnostic error.
+- `flows/<index>-<journey>/...` — Generated Maestro YAML when a segment used LLM flow generation.
+- `evidence/<index>-<journey>/...` — Hierarchy text and screenshots captured for assertions.
+
+Exit codes are intentionally stable for CI:
+
+| Code | Classification | Summary error kind |
+|------|----------------|--------------------|
+| `0` | All journeys passed | none |
+| `2` | Input or parser failure | `parser_failure` |
+| `3` | Setup or required artifact write failure | `setup_failure` |
+| `4` | Journey execution or assertion failure | `journey_failure` |
+
+Required suite artifacts (`summary.json` and journey result JSON) are part of the command outcome. Optional evidence writes, such as generated flows, hierarchy captures, and screenshots, are recorded when available but do not fail the journey solely because the artifact path cannot be written.
+
 ---
 
 ## Execution Data Flow

--- a/docs/superpowers/plans/2026-07-08-suite-artifacts.md
+++ b/docs/superpowers/plans/2026-07-08-suite-artifacts.md
@@ -1,0 +1,1386 @@
+# Suite Artifacts And CI Results Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist durable `verity run` artifacts, generated flows, structured journey results, suite summaries, and CI-friendly exit codes.
+
+**Architecture:** Put stable serializable result contracts in `:verity:core`, collect segment-level metadata in `:verity:agent`, and keep filesystem layout plus suite writing in `:verity:cli`. `RunCommand` creates one timestamped run directory per invocation and passes a journey-scoped artifact recorder into `Orchestrator` so the agent can save evidence at the point it is produced without owning the output root.
+
+**Tech Stack:** Kotlin/JVM 21, kotlinx.serialization JSON, Clikt, coroutines, assertk, kotlinx-coroutines-test, Gradle via `rtk ./gradlew`.
+
+---
+
+## File Structure
+
+- Create `verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt`: serializable DTOs and stable lowercase enums for suite summaries, journey results, segment results, evidence references, and errors.
+- Create `verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt`: JSON contract tests for field names and enum wire values.
+- Modify `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/OrchestratorResult.kt`: add execution metadata fields to `SegmentResult` and `JourneyResult`.
+- Create `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/JourneyArtifactRecorder.kt`: small interface used by `Orchestrator` to persist generated flows and evidence.
+- Modify `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt`: accept the recorder, write slow-path YAML before execution, save visual screenshots and tree hierarchy evidence, and populate segment metadata.
+- Modify `verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt`: prove metadata and recorder calls for fast path, slow path, loop fallback, tree assertions, and visual assertions.
+- Create `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt`: run directory naming, slugging, journey artifact contexts, JSON writing, and `JourneyArtifactRecorder` implementation.
+- Modify `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`: create run artifacts, write per-journey JSON and `summary.json`, pass recorders into orchestrators, continue suite execution after journey failures, and map exit codes.
+- Modify `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`: assert artifact files, relative references, and exit codes using injected runner/clock.
+- Modify `docs/architecture.md`: document artifact layout, result contract, module ownership, and exit-code table.
+
+## Task 1: Core Result Contract
+
+**Files:**
+- Create: `verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt`
+- Create: `verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt`
+
+- [ ] **Step 1: Write failing serialization tests**
+
+Create `verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt`:
+
+```kotlin
+package me.chrisbanes.verity.core.result
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.serialization.json.Json
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Platform
+
+class RunResultContractTest {
+  private val json = Json {
+    prettyPrint = false
+    encodeDefaults = true
+    explicitNulls = false
+  }
+
+  @Test
+  fun `journey result serializes stable lowercase values and camelCase fields`() {
+    val result = JourneyArtifactResult(
+      journey = JourneyArtifactIdentity(
+        name = "Login",
+        file = "journeys/login.journey.yaml",
+        app = "com.example.app",
+        platform = Platform.ANDROID_TV,
+      ),
+      passed = false,
+      failedAt = 2,
+      segments = listOf(
+        SegmentArtifactResult(
+          index = 2,
+          passed = false,
+          executionMode = SegmentExecutionMode.SLOW,
+          actions = listOf("Navigate to Settings"),
+          assertion = AssertionArtifact(description = "Settings is visible", mode = AssertMode.TREE),
+          reasoning = "Expected Settings but saw Home",
+          generatedFlows = listOf("flows/001-login/segment-002-actions.yaml"),
+          evidence = listOf(
+            EvidenceArtifact(type = EvidenceType.HIERARCHY, path = "evidence/001-login/segment-002-tree.txt"),
+          ),
+          error = ArtifactError(kind = ArtifactErrorKind.JOURNEY_FAILURE, message = "Expected Settings but saw Home"),
+        ),
+      ),
+    )
+
+    val encoded = json.encodeToString(JourneyArtifactResult.serializer(), result)
+
+    assertThat(encoded).contains("\"platform\":\"android-tv\"")
+    assertThat(encoded).contains("\"executionMode\":\"slow\"")
+    assertThat(encoded).contains("\"mode\":\"tree\"")
+    assertThat(encoded).contains("\"type\":\"hierarchy\"")
+    assertThat(encoded).contains("\"kind\":\"journey_failure\"")
+    assertThat(encoded).contains("\"generatedFlows\"")
+  }
+
+  @Test
+  fun `suite summary serializes status counts and journey references`() {
+    val summary = SuiteArtifactSummary(
+      formatVersion = 1,
+      timestamp = "2026-07-08T14:35:12Z",
+      inputPath = "journeys",
+      status = ArtifactStatus.FAILED,
+      total = 2,
+      passed = 1,
+      failed = 1,
+      journeys = listOf(
+        SuiteJourneyArtifact(path = "journeys/001-login.json", name = "Login", status = ArtifactStatus.PASSED),
+        SuiteJourneyArtifact(path = "journeys/002-browse.json", name = "Browse", status = ArtifactStatus.FAILED),
+      ),
+      error = ArtifactError(kind = ArtifactErrorKind.JOURNEY_FAILURE, message = "One or more journeys failed"),
+    )
+
+    val encoded = json.encodeToString(SuiteArtifactSummary.serializer(), summary)
+
+    assertThat(encoded).contains("\"formatVersion\":1")
+    assertThat(encoded).contains("\"status\":\"failed\"")
+    assertThat(encoded).contains("\"passed\":1")
+    assertThat(encoded).contains("\"failed\":1")
+    assertThat(encoded).contains("\"path\":\"journeys/001-login.json\"")
+  }
+
+  @Test
+  fun `platform and assert mode decode from stable wire values`() {
+    val decoded = json.decodeFromString(
+      JourneyArtifactResult.serializer(),
+      """
+      {
+        "journey":{"name":"Login","file":"login.journey.yaml","app":"com.example.app","platform":"android"},
+        "passed":true,
+        "segments":[{"index":0,"passed":true,"executionMode":"assertion-only","assertion":{"description":"Home","mode":"visible"}}]
+      }
+      """.trimIndent(),
+    )
+
+    assertThat(decoded.journey.platform).isEqualTo(Platform.ANDROID_MOBILE)
+    assertThat(decoded.segments.single().assertion?.mode).isEqualTo(AssertMode.VISIBLE)
+    assertThat(decoded.segments.single().executionMode).isEqualTo(SegmentExecutionMode.ASSERTION_ONLY)
+  }
+}
+```
+
+- [ ] **Step 2: Run the core result contract tests and verify failure**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.result.RunResultContractTest"
+```
+
+Expected: compile failure because `me.chrisbanes.verity.core.result` types do not exist.
+
+- [ ] **Step 3: Add serializable result DTOs**
+
+Create `verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt`:
+
+```kotlin
+package me.chrisbanes.verity.core.result
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Platform
+
+@Serializable
+data class JourneyArtifactIdentity(
+  val name: String,
+  val file: String,
+  val app: String,
+  @Serializable(with = PlatformWireSerializer::class) val platform: Platform,
+)
+
+@Serializable
+data class AssertionArtifact(
+  val description: String,
+  @Serializable(with = AssertModeWireSerializer::class) val mode: AssertMode,
+)
+
+@Serializable
+data class EvidenceArtifact(
+  val type: EvidenceType,
+  val path: String,
+)
+
+@Serializable
+data class ArtifactError(
+  val kind: ArtifactErrorKind,
+  val message: String,
+)
+
+@Serializable
+data class SegmentArtifactResult(
+  val index: Int,
+  val passed: Boolean,
+  val executionMode: SegmentExecutionMode,
+  val actions: List<String> = emptyList(),
+  val assertion: AssertionArtifact? = null,
+  val reasoning: String = "",
+  val generatedFlows: List<String> = emptyList(),
+  val evidence: List<EvidenceArtifact> = emptyList(),
+  val error: ArtifactError? = null,
+)
+
+@Serializable
+data class JourneyArtifactResult(
+  val journey: JourneyArtifactIdentity,
+  val passed: Boolean,
+  val failedAt: Int? = null,
+  val segments: List<SegmentArtifactResult> = emptyList(),
+)
+
+@Serializable
+data class SuiteJourneyArtifact(
+  val path: String,
+  val name: String,
+  val status: ArtifactStatus,
+)
+
+@Serializable
+data class SuiteArtifactSummary(
+  val formatVersion: Int,
+  val timestamp: String,
+  val inputPath: String,
+  val status: ArtifactStatus,
+  val total: Int,
+  val passed: Int,
+  val failed: Int,
+  val journeys: List<SuiteJourneyArtifact> = emptyList(),
+  val error: ArtifactError? = null,
+  val platform: String? = null,
+  val provider: String? = null,
+  val navigatorModel: String? = null,
+  val inspectorModel: String? = null,
+)
+
+@Serializable
+enum class ArtifactStatus {
+  @SerialName("passed") PASSED,
+  @SerialName("failed") FAILED,
+}
+
+@Serializable
+enum class SegmentExecutionMode {
+  @SerialName("fast") FAST,
+  @SerialName("slow") SLOW,
+  @SerialName("loop") LOOP,
+  @SerialName("assertion-only") ASSERTION_ONLY,
+}
+
+@Serializable
+enum class EvidenceType {
+  @SerialName("flow") FLOW,
+  @SerialName("screenshot") SCREENSHOT,
+  @SerialName("hierarchy") HIERARCHY,
+}
+
+@Serializable
+enum class ArtifactErrorKind {
+  @SerialName("parser_failure") PARSER_FAILURE,
+  @SerialName("setup_failure") SETUP_FAILURE,
+  @SerialName("journey_failure") JOURNEY_FAILURE,
+}
+
+object PlatformWireSerializer : KSerializer<Platform> {
+  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Platform", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: Platform) = encoder.encodeString(
+    when (value) {
+      Platform.ANDROID_TV -> "android-tv"
+      Platform.ANDROID_MOBILE -> "android"
+      Platform.IOS -> "ios"
+    },
+  )
+
+  override fun deserialize(decoder: Decoder): Platform = when (val value = decoder.decodeString()) {
+    "android-tv" -> Platform.ANDROID_TV
+    "android" -> Platform.ANDROID_MOBILE
+    "ios" -> Platform.IOS
+    else -> error("Unknown platform: $value")
+  }
+}
+
+object AssertModeWireSerializer : KSerializer<AssertMode> {
+  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("AssertMode", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: AssertMode) = encoder.encodeString(value.name.lowercase())
+
+  override fun deserialize(decoder: Decoder): AssertMode = when (val value = decoder.decodeString()) {
+    "visible" -> AssertMode.VISIBLE
+    "focused" -> AssertMode.FOCUSED
+    "tree" -> AssertMode.TREE
+    "visual" -> AssertMode.VISUAL
+    else -> error("Unknown assert mode: $value")
+  }
+}
+```
+
+- [ ] **Step 4: Run core result contract tests and verify pass**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:core:test --tests "me.chrisbanes.verity.core.result.RunResultContractTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit core result contract**
+
+Run:
+
+```bash
+rtk git add verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt
+rtk git commit -m "Add run artifact result contract"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Agent Artifact Metadata And Recorder Interface
+
+**Files:**
+- Create: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/JourneyArtifactRecorder.kt`
+- Modify: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/OrchestratorResult.kt`
+- Modify: `verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt`
+
+- [ ] **Step 1: Write failing agent metadata tests**
+
+Append these tests to `verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt` before the companion object:
+
+```kotlin
+  @Test
+  fun `fast path segment records execution mode and source actions`() = runTest {
+    val session = FakeDeviceSession()
+    val recorder = RecordingArtifactRecorder()
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = { InspectorAgent(treeAgentFactory = { FakeTextAgent { error("unused") } }, evaluateVisualContent = { _, _, _ -> error("unused") }) },
+      artifactRecorder = recorder,
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "fast",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Action("scroll down")),
+      ),
+    )
+
+    assertThat(result.segments.single().executionMode).isEqualTo(SegmentExecutionMode.FAST)
+    assertThat(result.segments.single().actions).containsExactly("scroll down")
+    assertThat(result.segments.single().generatedFlows).isEmpty()
+  }
+
+  @Test
+  fun `slow path segment records generated flow reference before execution`() = runTest {
+    val session = FakeDeviceSession()
+    val recorder = RecordingArtifactRecorder()
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { "appId: $APP_ID\n---\n- tapOn: \"Settings\"" } } },
+      inspectorFactory = { InspectorAgent(treeAgentFactory = { FakeTextAgent { error("unused") } }, evaluateVisualContent = { _, _, _ -> error("unused") }) },
+      artifactRecorder = recorder,
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "slow",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Action("navigate to settings page")),
+      ),
+    )
+
+    assertThat(result.segments.single().executionMode).isEqualTo(SegmentExecutionMode.SLOW)
+    assertThat(result.segments.single().generatedFlows).containsExactly("flows/segment-000-actions.yaml")
+    assertThat(recorder.generatedFlows).containsExactly("0:actions:appId: $APP_ID\n---\n- tapOn: \"Settings\"")
+  }
+
+  @Test
+  fun `tree assertion records hierarchy evidence`() = runTest {
+    val session = FakeDeviceSession()
+    val recorder = RecordingArtifactRecorder()
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = { InspectorAgent(treeAgentFactory = { FakeTextAgent { "{\"passed\":true,\"reasoning\":\"Tree ok\"}" } }, evaluateVisualContent = { _, _, _ -> error("unused") }) },
+      artifactRecorder = recorder,
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "tree",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Assert("Home", AssertMode.TREE)),
+      ),
+    )
+
+    assertThat(result.segments.single().evidence.map { it.path }).containsExactly("evidence/segment-000-tree.txt")
+    assertThat(recorder.hierarchies.single()).contains("text=Home")
+  }
+
+  @Test
+  fun `visual assertion records screenshot evidence`() = runTest {
+    val session = FakeDeviceSession()
+    val recorder = RecordingArtifactRecorder()
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = { InspectorAgent(treeAgentFactory = { FakeTextAgent { error("unused") } }, evaluateVisualContent = { _, _, path -> "{\"passed\":true,\"reasoning\":\"Visual ok at $path\"}" }) },
+      artifactRecorder = recorder,
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "visual",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Assert("Logo visible", AssertMode.VISUAL)),
+      ),
+    )
+
+    assertThat(result.segments.single().evidence.map { it.path }).containsExactly("evidence/segment-000-visual.png")
+    assertThat(recorder.screenshotRequests).containsExactly(0)
+  }
+```
+
+Add this nested recorder class near the existing fake session:
+
+```kotlin
+  private class RecordingArtifactRecorder : JourneyArtifactRecorder {
+    val generatedFlows = mutableListOf<String>()
+    val hierarchies = mutableListOf<String>()
+    val screenshotRequests = mutableListOf<Int>()
+
+    override suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String {
+      generatedFlows += "$segmentIndex:$label:$yaml"
+      return "flows/segment-${segmentIndex.toString().padStart(3, '0')}-$label.yaml"
+    }
+
+    override suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String {
+      hierarchies += hierarchy
+      return "evidence/segment-${segmentIndex.toString().padStart(3, '0')}-tree.txt"
+    }
+
+    override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact {
+      screenshotRequests += segmentIndex
+      return JourneyScreenshotArtifact(
+        path = java.nio.file.Files.createTempFile("verity-visual-test", ".png"),
+        relativePath = "evidence/segment-${segmentIndex.toString().padStart(3, '0')}-visual.png",
+      )
+    }
+  }
+```
+
+Add imports if missing:
+
+```kotlin
+import assertk.assertions.contains
+import me.chrisbanes.verity.core.result.SegmentExecutionMode
+```
+
+- [ ] **Step 2: Run agent tests and verify failure**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:agent:test --tests "me.chrisbanes.verity.agent.OrchestratorTest"
+```
+
+Expected: compile failure because `JourneyArtifactRecorder`, `JourneyScreenshotArtifact`, and new segment fields do not exist.
+
+- [ ] **Step 3: Add recorder interface**
+
+Create `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/JourneyArtifactRecorder.kt`:
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import java.nio.file.Path
+
+interface JourneyArtifactRecorder {
+  suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String? = null
+
+  suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String? = null
+
+  suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact? = null
+}
+
+data class JourneyScreenshotArtifact(
+  val path: Path,
+  val relativePath: String,
+)
+
+object NoOpJourneyArtifactRecorder : JourneyArtifactRecorder
+```
+
+- [ ] **Step 4: Add segment metadata fields**
+
+Modify `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/OrchestratorResult.kt`:
+
+```kotlin
+package me.chrisbanes.verity.agent
+
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.result.ArtifactError
+import me.chrisbanes.verity.core.result.EvidenceArtifact
+import me.chrisbanes.verity.core.result.SegmentExecutionMode
+
+data class SegmentResult(
+  val index: Int,
+  val passed: Boolean,
+  val assertionMode: AssertMode? = null,
+  val assertionDescription: String? = null,
+  val reasoning: String = "",
+  val executionMode: SegmentExecutionMode = SegmentExecutionMode.ASSERTION_ONLY,
+  val actions: List<String> = emptyList(),
+  val generatedFlows: List<String> = emptyList(),
+  val evidence: List<EvidenceArtifact> = emptyList(),
+  val error: ArtifactError? = null,
+)
+
+data class JourneyResult(
+  val journeyName: String,
+  val segments: List<SegmentResult>,
+) {
+  val passed: Boolean get() = segments.all { it.passed }
+  val failedAt: Int? get() = segments.firstOrNull { !it.passed }?.index
+}
+
+data class LoopResult(
+  val satisfied: Boolean,
+  val iterations: Int,
+  val reasoning: String = "",
+  val generatedFlows: List<String> = emptyList(),
+)
+```
+
+- [ ] **Step 5: Leave metadata changes uncommitted for Task 3**
+
+Run:
+
+```bash
+rtk git status --short
+```
+
+Expected: the new recorder interface, updated result types, and failing tests are present in the worktree. Do not commit yet because Task 3 completes the implementation that makes these tests pass.
+
+## Task 3: Orchestrator Artifact Capture
+
+**Files:**
+- Modify: `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt`
+- Modify: `verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt`
+
+- [ ] **Step 1: Update `Orchestrator` constructor and slow-path capture**
+
+Modify the constructor and slow-path helper in `verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt`:
+
+```kotlin
+class Orchestrator(
+  private val session: DeviceSession,
+  private val navigatorFactory: () -> NavigatorAgent,
+  private val inspectorFactory: () -> InspectorAgent,
+  private val context: String = "",
+  private val artifactRecorder: JourneyArtifactRecorder = NoOpJourneyArtifactRecorder,
+) {
+```
+
+Add this private result type and helper near `executeSlowPath`:
+
+```kotlin
+  private data class ExecutedFlow(
+    val result: FlowResult,
+    val reference: String?,
+  )
+
+  private suspend fun executeSlowPath(
+    instructions: List<String>,
+    appId: String,
+    platform: Platform,
+    navigator: NavigatorAgent,
+    segmentIndex: Int,
+    label: String,
+  ): ExecutedFlow {
+    val yaml = navigator.generate(instructions, appId, platform, context)
+    val reference = artifactRecorder.saveGeneratedFlow(segmentIndex, label, yaml)
+    return ExecutedFlow(result = session.executeFlow(yaml), reference = reference)
+  }
+```
+
+Replace existing calls to `executeSlowPath(...)` with the new signature and use `flow.reference` when building `SegmentResult`.
+
+- [ ] **Step 2: Populate action segment metadata**
+
+In `executeSegment`, replace the action execution block with this logic:
+
+```kotlin
+    var executionMode = SegmentExecutionMode.ASSERTION_ONLY
+    val generatedFlows = mutableListOf<String>()
+
+    if (segment.actions.isNotEmpty()) {
+      val instructions = segment.actions.map { it.instruction }
+      if (isFastPath(instructions, platform)) {
+        executionMode = SegmentExecutionMode.FAST
+        executeFastPath(instructions, appId, platform, navigator)
+      } else {
+        executionMode = SegmentExecutionMode.SLOW
+        val flow = executeSlowPath(
+          instructions = instructions,
+          appId = appId,
+          platform = platform,
+          navigator = navigator,
+          segmentIndex = segment.index,
+          label = "actions",
+        )
+        flow.reference?.let(generatedFlows::add)
+        if (!flow.result.success) {
+          return SegmentResult(
+            index = segment.index,
+            passed = false,
+            reasoning = "Flow execution failed: ${flow.result.output}",
+            executionMode = executionMode,
+            actions = instructions,
+            generatedFlows = generatedFlows,
+            error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "Flow execution failed: ${flow.result.output}"),
+          )
+        }
+      }
+    }
+```
+
+Add imports:
+
+```kotlin
+import me.chrisbanes.verity.core.result.ArtifactError
+import me.chrisbanes.verity.core.result.ArtifactErrorKind
+import me.chrisbanes.verity.core.result.EvidenceArtifact
+import me.chrisbanes.verity.core.result.EvidenceType
+import me.chrisbanes.verity.core.result.SegmentExecutionMode
+```
+
+- [ ] **Step 3: Capture loop generated flow references**
+
+Change `executeLoop` so fallback slow-path iterations save `label = "loop-${actionsExecuted.toString().padStart(3, '0')}"` and append returned references to `LoopResult.generatedFlows`:
+
+```kotlin
+    val generatedFlows = mutableListOf<String>()
+
+    repeat(max) {
+      if (session.containsText(until)) {
+        return LoopResult(true, actionsExecuted, "Text '$until' found after $actionsExecuted iterations", generatedFlows)
+      }
+
+      if (interaction != null) {
+        executor.execute(interaction)
+        actionsExecuted += 1
+      } else {
+        val flow = executeSlowPath(
+          instructions = listOf(action),
+          appId = appId,
+          platform = platform,
+          navigator = navigator,
+          segmentIndex = segmentIndex,
+          label = "loop-${actionsExecuted.toString().padStart(3, '0')}",
+        )
+        flow.reference?.let(generatedFlows::add)
+        if (!flow.result.success) {
+          return LoopResult(false, actionsExecuted, "Loop flow execution failed: ${flow.result.output}", generatedFlows)
+        }
+        actionsExecuted += 1
+      }
+    }
+```
+
+Pass `segment.index` into `executeLoop` and build loop `SegmentResult` with `executionMode = SegmentExecutionMode.LOOP`, `actions = listOf(loop.action)`, and `generatedFlows = loopResult.generatedFlows`.
+
+- [ ] **Step 4: Capture tree and visual evidence**
+
+Change tree assertion evaluation to save the hierarchy string:
+
+```kotlin
+    AssertMode.TREE -> {
+      val hierarchy = session.captureHierarchy(HierarchyFilter.CONTENT)
+      val reference = artifactRecorder.saveHierarchy(segmentIndex, hierarchy)
+      val verdict = inspector.evaluateTree(hierarchy, description)
+      AssertionEvaluation(
+        verdict = verdict,
+        evidence = listOfNotNull(reference?.let { EvidenceArtifact(EvidenceType.HIERARCHY, it) }),
+      )
+    }
+```
+
+Change visual assertion evaluation to ask the recorder for a persistent screenshot path and fall back to the existing temp-file cleanup when the recorder returns null:
+
+```kotlin
+    AssertMode.VISUAL -> {
+      val artifact = artifactRecorder.screenshotPath(segmentIndex)
+      val screenshotPath = artifact?.path ?: withContext(Dispatchers.IO) { Files.createTempFile("verity-screenshot-", ".png") }
+      try {
+        session.captureScreenshot(screenshotPath)
+        val verdict = inspector.evaluateVisual(screenshotPath, description)
+        AssertionEvaluation(
+          verdict = verdict,
+          evidence = listOfNotNull(artifact?.relativePath?.let { EvidenceArtifact(EvidenceType.SCREENSHOT, it) }),
+        )
+      } finally {
+        if (artifact == null) {
+          withContext(NonCancellable + Dispatchers.IO) { Files.deleteIfExists(screenshotPath) }
+        }
+      }
+    }
+```
+
+Use a small private data class:
+
+```kotlin
+  private data class AssertionEvaluation(
+    val verdict: InspectionVerdict,
+    val evidence: List<EvidenceArtifact> = emptyList(),
+  )
+```
+
+Then build assertion `SegmentResult` with `assertionMode = assert.mode`, `assertionDescription = assert.description`, `reasoning`, `evidence`, `actions = segment.actions.map { it.instruction }`, and `executionMode` from earlier action handling.
+
+- [ ] **Step 5: Run agent tests and verify pass**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:agent:test --tests "me.chrisbanes.verity.agent.OrchestratorTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit orchestrator artifact capture**
+
+Run:
+
+```bash
+rtk git add verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/JourneyArtifactRecorder.kt verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/OrchestratorResult.kt verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
+rtk git commit -m "Capture journey segment artifacts"
+```
+
+Expected: commit succeeds.
+
+## Task 4: CLI Artifact Writer
+
+**Files:**
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt`
+- Add tests in: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`
+
+- [ ] **Step 1: Write failing artifact writer tests**
+
+Append this test to `RunCommandTest`:
+
+```kotlin
+  @Test
+  fun `run artifacts create stable directories and relative references`() = kotlinx.coroutines.test.runTest {
+    val dir = createTempDirectory("verity-artifacts").toFile()
+    try {
+      val writer = RunArtifactWriter(
+        outputRoot = dir,
+        clock = java.time.Clock.fixed(java.time.Instant.parse("2026-07-08T14:35:12Z"), java.time.ZoneOffset.UTC),
+      )
+      val run = writer.createRun(suiteSlugSource = "My Suite")
+      val journey = run.journey(index = 1, name = "Login")
+
+      val flow = journey.saveGeneratedFlow(segmentIndex = 2, label = "actions", yaml = "appId: com.example\n---\n- tapOn: Settings")
+      val tree = journey.saveHierarchy(segmentIndex = 2, hierarchy = "[text=Home]")
+      val screenshot = journey.screenshotPath(segmentIndex = 3)
+
+      assertThat(run.directory.toFile().name).isEqualTo("20260708-143512-my-suite")
+      assertThat(flow).isEqualTo("flows/001-login/segment-002-actions.yaml")
+      assertThat(tree).isEqualTo("evidence/001-login/segment-002-tree.txt")
+      assertThat(screenshot.relativePath).isEqualTo("evidence/001-login/segment-003-visual.png")
+      assertThat(File(run.directory.toFile(), flow).readText()).contains("tapOn: Settings")
+      assertThat(File(run.directory.toFile(), tree).readText()).isEqualTo("[text=Home]")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+```
+
+Add imports:
+
+```kotlin
+import assertk.assertions.isEqualTo
+```
+
+- [ ] **Step 2: Run the new CLI test and verify failure**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests "me.chrisbanes.verity.cli.RunCommandTest.run artifacts create stable directories and relative references"
+```
+
+Expected: compile failure because `RunArtifactWriter` does not exist.
+
+- [ ] **Step 3: Implement artifact writer and journey recorder**
+
+Create `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt`:
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import me.chrisbanes.verity.agent.JourneyArtifactRecorder
+import me.chrisbanes.verity.agent.JourneyScreenshotArtifact
+import me.chrisbanes.verity.core.result.JourneyArtifactResult
+import me.chrisbanes.verity.core.result.SuiteArtifactSummary
+
+class RunArtifactWriter(
+  private val outputRoot: File,
+  private val clock: Clock = Clock.systemUTC(),
+) {
+  private val json = Json {
+    prettyPrint = true
+    encodeDefaults = true
+    explicitNulls = false
+  }
+
+  suspend fun createRun(suiteSlugSource: String): RunArtifactDirectory = withContext(Dispatchers.IO) {
+    val timestamp = DATE_FORMAT.format(clock.instant().atZone(ZoneOffset.UTC))
+    val directory = outputRoot.toPath().resolve("runs").resolve("$timestamp-${slugArtifactName(suiteSlugSource, "run")}")
+    Files.createDirectories(directory)
+    RunArtifactDirectory(directory = directory, json = json)
+  }
+
+  private companion object {
+    val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+  }
+}
+
+class RunArtifactDirectory(
+  val directory: Path,
+  private val json: Json,
+) {
+  fun journey(index: Int, name: String): JourneyRunArtifactRecorder {
+    val key = "${index.toString().padStart(3, '0')}-${slugArtifactName(name, "journey")}"
+    return JourneyRunArtifactRecorder(directory = directory, key = key)
+  }
+
+  suspend fun writeJourneyResult(path: String, result: JourneyArtifactResult) = withContext(Dispatchers.IO) {
+    val target = directory.resolve(path)
+    Files.createDirectories(target.parent)
+    Files.writeString(target, json.encodeToString(JourneyArtifactResult.serializer(), result))
+  }
+
+  suspend fun writeSummary(summary: SuiteArtifactSummary) = withContext(Dispatchers.IO) {
+    Files.writeString(directory.resolve("summary.json"), json.encodeToString(SuiteArtifactSummary.serializer(), summary))
+  }
+}
+
+internal fun slugArtifactName(value: String, fallback: String): String {
+  val slug = value.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
+  return slug.ifEmpty { fallback }
+}
+
+class JourneyRunArtifactRecorder(
+  private val directory: Path,
+  private val key: String,
+) : JourneyArtifactRecorder {
+  override suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String = withContext(Dispatchers.IO) {
+    val relative = "flows/$key/segment-${segmentIndex.toString().padStart(3, '0')}-$label.yaml"
+    val target = directory.resolve(relative)
+    Files.createDirectories(target.parent)
+    Files.writeString(target, yaml)
+    relative
+  }
+
+  override suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String = withContext(Dispatchers.IO) {
+    val relative = "evidence/$key/segment-${segmentIndex.toString().padStart(3, '0')}-tree.txt"
+    val target = directory.resolve(relative)
+    Files.createDirectories(target.parent)
+    Files.writeString(target, hierarchy)
+    relative
+  }
+
+  override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact = withContext(Dispatchers.IO) {
+    val relative = "evidence/$key/segment-${segmentIndex.toString().padStart(3, '0')}-visual.png"
+    val target = directory.resolve(relative)
+    Files.createDirectories(target.parent)
+    JourneyScreenshotArtifact(path = target, relativePath = relative)
+  }
+}
+```
+
+- [ ] **Step 4: Run artifact writer test and verify pass**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests "me.chrisbanes.verity.cli.RunCommandTest.run artifacts create stable directories and relative references"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit CLI artifact writer**
+
+Run:
+
+```bash
+rtk git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+rtk git commit -m "Add CLI run artifact writer"
+```
+
+Expected: commit succeeds.
+
+## Task 5: RunCommand Summary Writing And Exit Codes
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+- Modify: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`
+
+- [ ] **Step 1: Write failing RunCommand artifact and exit-code tests**
+
+Change the helper at the bottom of `RunCommandTest` to accept a clock, then add these tests:
+
+```kotlin
+  private fun runCommand(
+    clock: java.time.Clock = java.time.Clock.systemUTC(),
+    runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
+  ): RunCommand = RunCommand(suiteRunner = runner, clock = clock)
+```
+
+```kotlin
+  @Test
+  fun `successful run writes journey result and suite summary`() {
+    val dir = createTempDirectory("verity-run-artifacts-success").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val output = File(dir, "out")
+      val command = runCommand(
+        clock = java.time.Clock.fixed(java.time.Instant.parse("2026-07-08T14:35:12Z"), java.time.ZoneOffset.UTC),
+      ) { journeys ->
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true))),
+            )
+          },
+        )
+      }
+
+      val result = Verity().subcommands(command).test("--output-path ${output.absolutePath} run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(0)
+      val runDir = output.resolve("runs/20260708-143512-single-journey")
+      assertThat(runDir.resolve("summary.json").isFile).isTrue()
+      assertThat(runDir.resolve("journeys/001-single-journey.json").isFile).isTrue()
+      assertThat(runDir.resolve("summary.json").readText()).contains("\"status\": \"passed\"")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `journey failure exits four and still writes failed summary`() {
+    val dir = createTempDirectory("verity-run-artifacts-fail").toFile()
+    try {
+      val file = writeJourney(dir, "failure.journey.yaml", "Failure journey")
+      val output = File(dir, "out")
+      val command = runCommand(
+        clock = java.time.Clock.fixed(java.time.Instant.parse("2026-07-08T14:35:12Z"), java.time.ZoneOffset.UTC),
+      ) { journeys ->
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(
+                resolved.journey.name,
+                listOf(SegmentResult(index = 0, passed = false, reasoning = "Expected Home")),
+              ),
+            )
+          },
+        )
+      }
+
+      val result = Verity().subcommands(command).test("--output-path ${output.absolutePath} run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(4)
+      assertThat(output.resolve("runs/20260708-143512-failure-journey/summary.json").readText()).contains("\"status\": \"failed\"")
+      assertThat(result.output).contains("Suite result: FAILED")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `parser input failure exits two and writes summary`() {
+    val dir = createTempDirectory("verity-run-artifacts-parser").toFile()
+    try {
+      val output = File(dir, "out")
+      val missing = File(dir, "missing.journey.yaml")
+
+      val result = Verity()
+        .subcommands(runCommand(clock = java.time.Clock.fixed(java.time.Instant.parse("2026-07-08T14:35:12Z"), java.time.ZoneOffset.UTC)) { error("unused") })
+        .test("--output-path ${output.absolutePath} run ${missing.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(2)
+      assertThat(output.resolve("runs/20260708-143512-missing-journey-yaml/summary.json").readText()).contains("\"kind\": \"parser_failure\"")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+```
+
+- [ ] **Step 2: Run RunCommand tests and verify failure**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests "me.chrisbanes.verity.cli.RunCommandTest"
+```
+
+Expected: failures because `RunCommand` does not accept a clock and does not write artifacts or return exit code `4` for journey failures.
+
+- [ ] **Step 3: Add clock injection and exit-code constants**
+
+Modify the `RunCommand` constructor:
+
+```kotlin
+class RunCommand(
+  private val loadJourney: (File, AssertionStrategy) -> Journey = JourneyLoader::fromFile,
+  private val listJourneyFiles: (File) -> List<File> = JourneyLoader::listJourneyFiles,
+  private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
+  private val clock: java.time.Clock = java.time.Clock.systemUTC(),
+) : CliktCommand(name = "run") {
+```
+
+Add constants near the data classes:
+
+```kotlin
+private const val EXIT_INPUT = 2
+private const val EXIT_SETUP = 3
+private const val EXIT_JOURNEY = 4
+```
+
+Use `CliktError(message, statusCode = EXIT_JOURNEY)` for journey failures and `CliktError(message, statusCode = EXIT_INPUT)` for input/parser failures.
+
+- [ ] **Step 4: Convert `JourneyResult` into core artifact DTOs**
+
+Add helpers to `RunCommand.kt`:
+
+```kotlin
+private fun ResolvedJourneyResult.toArtifactResult(filePath: String): JourneyArtifactResult = JourneyArtifactResult(
+  journey = JourneyArtifactIdentity(
+    name = resolvedJourney.journey.name,
+    file = filePath,
+    app = resolvedJourney.journey.app,
+    platform = resolvedJourney.journey.platform,
+  ),
+  passed = result.passed,
+  failedAt = result.failedAt,
+  segments = result.segments.map { segment ->
+    SegmentArtifactResult(
+      index = segment.index,
+      passed = segment.passed,
+      executionMode = segment.executionMode,
+      actions = segment.actions,
+      assertion = segment.assertionMode?.let {
+        AssertionArtifact(description = segment.assertionDescription.orEmpty(), mode = it)
+      },
+      reasoning = segment.reasoning,
+      generatedFlows = segment.generatedFlows,
+      evidence = segment.evidence,
+      error = segment.error,
+    )
+  },
+)
+```
+
+- [ ] **Step 5: Create run directory before resolving journeys and write summaries**
+
+In `RunCommand.run`, after resolving config and `path`, create the writer and run directory before `resolveJourneys`:
+
+```kotlin
+    val artifactWriter = RunArtifactWriter(resolved.outputPath, clock)
+    val runArtifacts = artifactWriter.createRun(suiteSlugSource = path.nameWithoutExtension.ifEmpty { path.name })
+```
+
+Wrap input parsing in `try/catch` and write a failed summary before throwing `CliktError(statusCode = EXIT_INPUT)`:
+
+```kotlin
+    val journeys = try {
+      resolveJourneys(path, resolved.assertionStrategy, resolved.platform)
+    } catch (e: Exception) {
+      runArtifacts.writeSummary(
+        SuiteArtifactSummary(
+          formatVersion = 1,
+          timestamp = java.time.Instant.now(clock).toString(),
+          inputPath = path.path,
+          status = ArtifactStatus.FAILED,
+          total = 0,
+          passed = 0,
+          failed = 0,
+          error = ArtifactError(ArtifactErrorKind.PARSER_FAILURE, e.message ?: "Journey input parsing failed"),
+        ),
+      )
+      throw CliktError(e.message ?: "Journey input parsing failed", statusCode = EXIT_INPUT)
+    }
+```
+
+After running the suite, write each journey result and summary:
+
+```kotlin
+    val suiteJourneys = mutableListOf<SuiteJourneyArtifact>()
+    suiteResult.results.forEachIndexed { index, item ->
+      val journeyKey = "${(index + 1).toString().padStart(3, '0')}-${slugArtifactName(item.resolvedJourney.journey.name, "journey")}" 
+      val resultPath = "journeys/$journeyKey.json"
+      runArtifacts.writeJourneyResult(resultPath, item.toArtifactResult(item.resolvedJourney.file.displayPath()))
+      suiteJourneys += SuiteJourneyArtifact(
+        path = resultPath,
+        name = item.resolvedJourney.journey.name,
+        status = if (item.result.passed) ArtifactStatus.PASSED else ArtifactStatus.FAILED,
+      )
+    }
+    runArtifacts.writeSummary(
+      SuiteArtifactSummary(
+        formatVersion = 1,
+        timestamp = java.time.Instant.now(clock).toString(),
+        inputPath = path.path,
+        status = if (suiteResult.passed) ArtifactStatus.PASSED else ArtifactStatus.FAILED,
+        total = suiteResult.results.size,
+        passed = suiteResult.passedCount,
+        failed = suiteResult.failedCount,
+        journeys = suiteJourneys,
+        error = if (suiteResult.passed) null else ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "One or more journeys failed"),
+      ),
+    )
+```
+
+Use the `slugArtifactName` function from `RunArtifacts.kt` for the journey result path so `journeys/`, `flows/`, and `evidence/` keys match exactly.
+
+- [ ] **Step 6: Pass journey-specific recorders into real orchestrators**
+
+Change `runSuiteWithDevice` to accept `runArtifacts: RunArtifactDirectory`, then create the orchestrator inside `journeys.mapIndexed` so each journey receives its recorder:
+
+```kotlin
+return SuiteRunResult(
+  journeys.mapIndexed { index, resolved ->
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = navigatorFactory,
+      inspectorFactory = inspectorFactory,
+      context = projectContext.text,
+      artifactRecorder = runArtifacts.journey(index + 1, resolved.journey.name),
+    )
+    ResolvedJourneyResult(
+      resolvedJourney = resolved,
+      result = orchestrator.run(resolved.journey),
+    )
+  },
+)
+```
+
+Before this return block, extract the existing inline `navigatorFactory = { ... }` and `inspectorFactory = { ... }` lambdas into local variables named exactly `navigatorFactory` and `inspectorFactory` so the snippet above compiles without changing their bodies.
+
+- [ ] **Step 7: Run RunCommand tests and update old exit-code expectations**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests "me.chrisbanes.verity.cli.RunCommandTest"
+```
+
+Expected: tests pass after updating existing failing journey assertions from status code `1` to `4`, and input/parser assertions from `1` to `2` where applicable.
+
+- [ ] **Step 8: Commit RunCommand artifact integration**
+
+Run:
+
+```bash
+rtk git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+rtk git commit -m "Write run artifact summaries"
+```
+
+Expected: commit succeeds.
+
+## Task 6: Setup Failure Summary And Architecture Docs
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+- Modify: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt`
+- Modify: `docs/architecture.md`
+
+- [ ] **Step 1: Write failing setup failure summary test**
+
+Add to `RunCommandSmokeTest`:
+
+```kotlin
+  @Test
+  fun `setup failure writes summary and exits three`() {
+    val journeyUrl = javaClass.classLoader.getResource("smoke/minimal.journey.yaml")!!
+    val output = kotlin.io.path.createTempDirectory("verity-setup-summary").toFile()
+    try {
+      val result = Verity()
+        .subcommands(RunCommand(), ListCommand(), McpCommand())
+        .test(
+          listOf(
+            "--provider", "ollama",
+            "--context-path", "/nonexistent/context",
+            "--require-context",
+            "--output-path", output.absolutePath,
+            "run",
+            java.io.File(journeyUrl.toURI()).absolutePath,
+          ),
+        )
+
+      assertThat(result.statusCode).isEqualTo(3)
+      val summary = output.resolve("runs").listFiles()!!.single().resolve("summary.json").readText()
+      assertThat(summary).contains("\"kind\": \"setup_failure\"")
+      assertThat(summary).contains("Required project context directory")
+    } finally {
+      output.deleteRecursively()
+    }
+  }
+```
+
+- [ ] **Step 2: Run smoke test and verify failure**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests "me.chrisbanes.verity.cli.RunCommandSmokeTest.setup failure writes summary and exits three"
+```
+
+Expected: failure because setup errors still exit `1` and may not write summaries.
+
+- [ ] **Step 3: Write setup failure summaries in `RunCommand`**
+
+Wrap `runSuiteWithDevice` invocation in `RunCommand.run`:
+
+```kotlin
+    val suiteResult = try {
+      suiteRunner?.invoke(journeys)
+        ?: runSuiteWithDevice(parent, config, resolved, path, journeys, runArtifacts)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: CliktError) {
+      runArtifacts.writeSummary(
+        SuiteArtifactSummary(
+          formatVersion = 1,
+          timestamp = java.time.Instant.now(clock).toString(),
+          inputPath = path.path,
+          status = ArtifactStatus.FAILED,
+          total = journeys.size,
+          passed = 0,
+          failed = journeys.size,
+          error = ArtifactError(ArtifactErrorKind.SETUP_FAILURE, e.message ?: "Setup failed"),
+        ),
+      )
+      throw CliktError(e.message ?: "Setup failed", statusCode = EXIT_SETUP)
+    }
+```
+
+Import `kotlin.coroutines.cancellation.CancellationException`.
+
+- [ ] **Step 4: Update `docs/architecture.md`**
+
+Add a new section after project configuration or CLI mode:
+
+```markdown
+## Run Artifacts And CI Results
+
+`verity run` always writes a timestamped run directory below the resolved `paths.output` / `--output-path` root. The default root is `build/verity`.
+
+```text
+build/verity/
+  runs/
+    20260708-143512-my-suite/
+      summary.json
+      journeys/
+        001-login.json
+      flows/
+        001-login/segment-002-actions.yaml
+      evidence/
+        001-login/segment-003-visual.png
+        001-login/segment-004-tree.txt
+```
+
+`summary.json` contains the output format version, timestamp, input path, overall status, pass/fail counts, journey result references, and top-level parser/setup/journey error details when present. Each journey result contains journey identity, app, platform, pass/fail state, first failed segment, segment execution mode, source actions, assertion mode, reasoning, generated flow references, evidence references, and structured segment errors.
+
+Module ownership:
+
+- `:verity:core` owns serializable result DTOs and stable JSON wire values.
+- `:verity:agent` owns segment metadata and calls a recorder when generated flows or assertion evidence are produced.
+- `:verity:cli` owns run directory layout, JSON writing, summary aggregation, and exit-code mapping.
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | All journeys passed. |
+| `2` | Input or parser failure. |
+| `3` | Setup, preflight, context, device, provider, model, credential, or artifact setup failure. |
+| `4` | One or more journeys ran and failed. |
+```
+
+- [ ] **Step 5: Run setup failure smoke test and docs-independent CLI tests**
+
+Run:
+
+```bash
+rtk ./gradlew :verity:cli:test --tests "me.chrisbanes.verity.cli.RunCommandSmokeTest" --tests "me.chrisbanes.verity.cli.RunCommandTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit setup failure and docs**
+
+Run:
+
+```bash
+rtk git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt docs/architecture.md
+rtk git commit -m "Document and handle run artifact failures"
+```
+
+Expected: commit succeeds.
+
+## Task 7: Full Verification And Cleanup
+
+**Files:**
+- Modify only files touched by earlier tasks to fix formatting, imports, or failing checks.
+
+- [ ] **Step 1: Run Spotless apply**
+
+Run:
+
+```bash
+rtk ./gradlew spotlessApply
+```
+
+Expected: task succeeds and formats Kotlin/docs as configured.
+
+- [ ] **Step 2: Run full checks**
+
+Run:
+
+```bash
+rtk ./gradlew check
+```
+
+Expected: PASS. If it fails, fix only the failing issue, rerun the narrow failing task, then rerun `rtk ./gradlew check`.
+
+- [ ] **Step 3: Inspect final diff and status**
+
+Run:
+
+```bash
+rtk git status --short
+rtk git diff --stat
+rtk git diff
+```
+
+Expected: only intentional changes remain. Do not revert unrelated user changes.
+
+- [ ] **Step 4: Commit verification fixes if needed**
+
+If Spotless or check fixes changed files, run:
+
+```bash
+rtk git add verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/JourneyArtifactRecorder.kt verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/OrchestratorResult.kt verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt docs/architecture.md
+rtk git commit -m "Polish suite artifact implementation"
+```
+
+Expected: commit succeeds. Skip this step if there are no uncommitted changes.
+
+## Self-Review Notes
+
+- Spec coverage: Tasks cover core result DTOs, timestamped run directories, per-journey JSON, suite summary JSON, generated-flow persistence, fast-path metadata, screenshot/tree evidence, exit codes, tests, and architecture docs.
+- Scope: This is one cohesive CLI run artifact feature across existing module boundaries. MCP behavior is explicitly excluded.
+- Type consistency: Plan uses `JourneyArtifactRecorder`, `JourneyScreenshotArtifact`, `SegmentExecutionMode`, `EvidenceArtifact`, and `ArtifactError` consistently across core, agent, and CLI tasks.

--- a/docs/superpowers/specs/2026-07-08-suite-artifacts-design.md
+++ b/docs/superpowers/specs/2026-07-08-suite-artifacts-design.md
@@ -1,0 +1,189 @@
+# Suite Artifacts And CI Results Design
+
+## Context
+
+GitHub issue 49 asks Verity to persist durable artifacts for single-journey and multi-journey runs. Today `verity run` prints pass/fail output and keeps only in-memory `JourneyResult` values. Generated Maestro YAML, visual assertion screenshots, hierarchy captures, per-journey outcomes, and suite summaries are not saved in a stable place for local debugging or CI collection.
+
+Recent work already added directory suite runs, project output configuration, and shared preflight checks. `RunCommand` resolves `paths.output` / `--output-path` to `build/verity` by default and owns suite aggregation. `Orchestrator` owns segment execution and is the only layer that knows whether a segment used fast-path direct interactions, generated slow-path YAML, loop YAML, assertion modes, screenshots, hierarchy text, and reasoning.
+
+## Goals
+
+- Create a timestamped output directory for every `verity run` invocation.
+- Write structured per-journey result files for both single-file and directory suite runs.
+- Write a structured aggregate suite summary with pass/fail counts and result file references.
+- Persist generated Maestro YAML for slow-path action segments and slow-path loop iterations using stable filenames.
+- Represent fast-path direct interactions in results even when no YAML is generated.
+- Reference generated flows, screenshots, hierarchy captures, and other evidence files from result JSON using stable relative paths.
+- Return distinct CI-friendly exit codes for input/parser failures, setup failures, and journey failures.
+- Document the artifact layout, result contract, and exit-code behavior in `docs/architecture.md`.
+
+## Non-Goals
+
+- Do not add an opt-out for artifact writing. Artifact persistence is the run contract and is always enabled for `verity run`.
+- Do not persist the internal temporary files created by the Maestro device runner. Those files remain implementation details and are still cleaned up.
+- Do not add a database, server-side artifact index, or retention policy.
+- Do not change MCP behavior. This issue concerns CLI journey runs.
+- Do not keep executing segments inside a journey after the first failed segment.
+
+## Architecture
+
+Add a small artifact subsystem without adding a new Gradle module.
+
+`:verity:core` should define serializable result contract DTOs so `agent`, `cli`, and tests share one stable schema. DTO properties must use Kotlin camelCase with `@SerialName` only where the JSON wire format differs. Stable enum values should serialize as lowercase strings.
+
+`:verity:agent` should enrich `JourneyResult` / `SegmentResult` or nearby result types with execution metadata collected while running segments:
+
+- segment index and pass/fail status
+- execution mode, such as `fast`, `slow`, `loop`, or `assertion-only`
+- source action strings and assertion details
+- assertion mode and reasoning
+- generated-flow references
+- evidence references
+- structured error details for failed segment work
+
+The agent should not decide the suite output root. Instead, `RunCommand` should pass an artifact recorder or per-journey artifact context into orchestration. This keeps CLI ownership of filesystem layout while allowing `Orchestrator` to write artifacts at the point it has the source data.
+
+`:verity:cli` should own run directory creation, suite summary writing, per-journey result writing, and exit-code mapping. It already resolves `outputPath`, runs one or more journeys, and prints aggregate results.
+
+## Artifact Layout
+
+Every `verity run` invocation creates a run directory below the resolved output path:
+
+```text
+<outputPath>/
+  runs/
+    <yyyyMMdd-HHmmss>-<suite-slug>/
+      summary.json
+      journeys/
+        001-login.json
+        002-browse-home.json
+      flows/
+        001-login/
+          segment-000-launch.yaml
+          segment-002-actions.yaml
+        002-browse-home/
+          segment-001-loop-003.yaml
+      evidence/
+        001-login/
+          segment-003-visual.png
+          segment-004-tree.txt
+```
+
+The default root remains `build/verity`, so a normal run writes to `build/verity/runs/<timestamp>-<suite-slug>/...`.
+
+Use these naming rules:
+
+- Run directory: timestamp plus a slug from the single journey name or directory name.
+- Journey artifacts: `<journey-index>-<journey-slug>`, where the index is one-based and zero-padded to three digits.
+- Segment artifacts: `segment-<segment-index>` with a zero-padded three-digit segment index.
+- Slow-path action YAML: `flows/<journey-key>/segment-<index>-actions.yaml`.
+- Loop fallback YAML: `flows/<journey-key>/segment-<index>-loop-<iteration>.yaml`.
+- Visual evidence: `evidence/<journey-key>/segment-<index>-visual.png`.
+- Tree evidence: `evidence/<journey-key>/segment-<index>-tree.txt`.
+
+All paths stored in JSON should be relative to the run directory, for example `flows/001-login/segment-002-actions.yaml`. Relative paths make artifacts movable and easy for CI systems to archive.
+
+## Result Contract
+
+Per-journey result JSON should include journey identity, source file, app, platform, pass/fail state, first failed segment, and segment details. A representative shape is:
+
+```json
+{
+  "journey": {
+    "name": "Login",
+    "file": "journeys/login.journey.yaml",
+    "app": "com.example.app",
+    "platform": "android-tv"
+  },
+  "passed": false,
+  "failedAt": 2,
+  "segments": [
+    {
+      "index": 2,
+      "passed": false,
+      "executionMode": "slow",
+      "actions": ["Navigate to Settings"],
+      "assertion": {
+        "description": "Settings is visible",
+        "mode": "tree"
+      },
+      "reasoning": "Expected Settings but saw Home",
+      "generatedFlows": ["flows/001-login/segment-002-actions.yaml"],
+      "evidence": [
+        {
+          "type": "hierarchy",
+          "path": "evidence/001-login/segment-002-tree.txt"
+        }
+      ],
+      "error": {
+        "kind": "journey_failure",
+        "message": "Expected Settings but saw Home"
+      }
+    }
+  ]
+}
+```
+
+`summary.json` should include:
+
+- run metadata: timestamp, output format version, input path, platform, provider/model IDs when available
+- overall status: `passed` or `failed`
+- counts: total, passed, failed
+- journey result references with file paths and status
+- top-level error details when parsing, setup, or preflight fails before any journey can run
+
+Use stable lowercase wire values:
+
+- status: `passed`, `failed`
+- execution mode: `fast`, `slow`, `loop`, `assertion-only`
+- assertion mode: existing assertion modes as lowercase strings
+- evidence type: `flow`, `screenshot`, `hierarchy`
+- error kind: `parser_failure`, `setup_failure`, `journey_failure`
+
+## Execution Behavior
+
+`RunCommand` should create the run directory before parsing and running journeys. This allows parser/input failures and setup/preflight failures to still produce a machine-readable `summary.json`.
+
+Exit codes should be stable for CI:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | All journeys passed. |
+| `2` | Input or parser failure, including missing journey files, invalid journey YAML, mixed-platform directory suites, or invalid CLI/config values needed to resolve input. |
+| `3` | Setup failure, including preflight, context validation, device setup, provider/model/credential setup, or LLM client construction failures. |
+| `4` | One or more journeys ran and failed. |
+
+Directory suite runs should continue to execute remaining journeys after one journey fails so `summary.json` can report complete pass/fail counts. A single journey should keep the current behavior of stopping at the first failed segment.
+
+Generated Maestro YAML persistence should happen before execution so failed flow execution still has the exact YAML that was attempted. The internal temp YAML file used by `device/MaestroFlowRunner` should remain temporary and should still be deleted in its `finally` block. Persisted YAML artifacts are separate explicit copies written under the run artifact directory.
+
+Fast-path interactions should not generate YAML files solely for persistence. They should be represented structurally in segment results using source action strings, execution mode `fast`, and any directly executed interaction details that are already available.
+
+Visual assertions should save the screenshot file used for evaluation under `evidence/`. Tree assertions should save the rendered hierarchy text under `evidence/`. Visible and focused assertions do not write evidence files for this issue.
+
+## Error Handling
+
+If creating the run directory or writing required result files fails before a journey result is available, `verity run` should fail as setup failure with exit code `3` because the artifact contract cannot be satisfied. If a journey already has a pass/fail result and writing additional optional evidence fails, the journey result should include an artifact error and the run should continue when possible.
+
+Suspend code that catches `Exception` must rethrow `CancellationException` first. Blocking filesystem operations such as creating directories and writing JSON should run on `Dispatchers.IO`.
+
+## Testing
+
+Add tests at the narrowest useful level:
+
+- `:verity:core` tests for JSON serialization of result contracts, stable lowercase enum wire values, and nullable optional fields.
+- `:verity:agent` tests with fake sessions for fast-path segment metadata, slow-path generated YAML references, loop fallback YAML references, tree evidence, visual screenshot evidence, and failed flow errors.
+- `:verity:cli` tests with injected suite runner, fake clock, and temporary output directory for run directory names, per-journey JSON files, `summary.json`, relative artifact paths, and exit codes.
+- Existing CLI suite aggregation tests should continue to pass after exit-code updates are reflected.
+
+The final implementation must run `./gradlew spotlessApply` and `./gradlew check`.
+
+## Documentation
+
+Update `docs/architecture.md` because this changes CLI behavior, shared data models, and result contracts. The documentation should include:
+
+- artifact directory layout
+- per-journey result shape
+- suite summary shape
+- exit-code table
+- ownership boundaries between `core`, `agent`, and `cli`

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/JourneyArtifactRecorder.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/JourneyArtifactRecorder.kt
@@ -1,0 +1,16 @@
+package me.chrisbanes.verity.agent
+
+import java.nio.file.Path
+
+interface JourneyArtifactRecorder {
+  suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String? = null
+  suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String? = null
+  suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact? = null
+}
+
+data class JourneyScreenshotArtifact(
+  val path: Path,
+  val relativePath: String,
+)
+
+object NoOpJourneyArtifactRecorder : JourneyArtifactRecorder

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
@@ -1,5 +1,6 @@
 package me.chrisbanes.verity.agent
 
+import java.io.IOException
 import java.nio.file.Files
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -350,7 +351,9 @@ class Orchestrator(
           true
         } catch (e: CancellationException) {
           throw e
-        } catch (_: Exception) {
+        } catch (_: IOException) {
+          false
+        } catch (_: SecurityException) {
           false
         }
         if (captured) {

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
@@ -345,23 +345,36 @@ class Orchestrator(
         null
       }
       if (artifact != null) {
-        session.captureScreenshot(artifact.path)
-        AssertionEvaluation(
-          verdict = inspector.evaluateVisual(artifact.path, description),
-          evidence = listOf(EvidenceArtifact(EvidenceType.SCREENSHOT, artifact.relativePath)),
-        )
-      } else {
-        val tempFile = withContext(Dispatchers.IO) {
-          Files.createTempFile("verity-screenshot-", ".png")
-        }
         try {
-          session.captureScreenshot(tempFile)
-          AssertionEvaluation(inspector.evaluateVisual(tempFile, description))
-        } finally {
-          withContext(NonCancellable + Dispatchers.IO) {
-            Files.deleteIfExists(tempFile)
-          }
+          session.captureScreenshot(artifact.path)
+          AssertionEvaluation(
+            verdict = inspector.evaluateVisual(artifact.path, description),
+            evidence = listOf(EvidenceArtifact(EvidenceType.SCREENSHOT, artifact.relativePath)),
+          )
+        } catch (e: CancellationException) {
+          throw e
+        } catch (_: Exception) {
+          evaluateVisualWithTempFile(inspector, description)
         }
+      } else {
+        evaluateVisualWithTempFile(inspector, description)
+      }
+    }
+  }
+
+  private suspend fun evaluateVisualWithTempFile(
+    inspector: InspectorAgent,
+    description: String,
+  ): AssertionEvaluation {
+    val tempFile = withContext(Dispatchers.IO) {
+      Files.createTempFile("verity-screenshot-", ".png")
+    }
+    try {
+      session.captureScreenshot(tempFile)
+      return AssertionEvaluation(inspector.evaluateVisual(tempFile, description))
+    } finally {
+      withContext(NonCancellable + Dispatchers.IO) {
+        Files.deleteIfExists(tempFile)
       }
     }
   }

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
@@ -345,15 +345,20 @@ class Orchestrator(
         null
       }
       if (artifact != null) {
-        try {
+        val captured = try {
           session.captureScreenshot(artifact.path)
+          true
+        } catch (e: CancellationException) {
+          throw e
+        } catch (_: Exception) {
+          false
+        }
+        if (captured) {
           AssertionEvaluation(
             verdict = inspector.evaluateVisual(artifact.path, description),
             evidence = listOf(EvidenceArtifact(EvidenceType.SCREENSHOT, artifact.relativePath)),
           )
-        } catch (e: CancellationException) {
-          throw e
-        } catch (_: Exception) {
+        } else {
           evaluateVisualWithTempFile(inspector, description)
         }
       } else {

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
@@ -15,6 +15,11 @@ import me.chrisbanes.verity.core.model.InspectionVerdict
 import me.chrisbanes.verity.core.model.Journey
 import me.chrisbanes.verity.core.model.JourneySegment
 import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.core.result.ArtifactError
+import me.chrisbanes.verity.core.result.ArtifactErrorKind
+import me.chrisbanes.verity.core.result.EvidenceArtifact
+import me.chrisbanes.verity.core.result.EvidenceType
+import me.chrisbanes.verity.core.result.SegmentExecutionMode
 import me.chrisbanes.verity.device.DeviceSession
 
 /**
@@ -27,6 +32,7 @@ class Orchestrator(
   private val navigatorFactory: () -> NavigatorAgent,
   private val inspectorFactory: () -> InspectorAgent,
   private val context: String = "",
+  private val artifactRecorder: JourneyArtifactRecorder = NoOpJourneyArtifactRecorder,
 ) {
   suspend fun run(journey: Journey): JourneyResult {
     // Launch the app before executing any segments.
@@ -56,18 +62,38 @@ class Orchestrator(
     navigator: NavigatorAgent,
     inspector: InspectorAgent,
   ): SegmentResult {
+    var executionMode = SegmentExecutionMode.ASSERTION_ONLY
+    var actions = emptyList<String>()
+    val generatedFlows = mutableListOf<String>()
+
     // Execute actions
     if (segment.actions.isNotEmpty()) {
       val instructions = segment.actions.map { it.instruction }
+      actions = instructions
       if (isFastPath(instructions, platform)) {
         executeFastPath(instructions, appId, platform, navigator)
+        executionMode = SegmentExecutionMode.FAST
       } else {
-        val flowResult = executeSlowPath(instructions, appId, platform, navigator)
-        if (!flowResult.success) {
+        val slowPathResult = executeSlowPath(
+          instructions = instructions,
+          appId = appId,
+          platform = platform,
+          navigator = navigator,
+          segmentIndex = segment.index,
+          label = "actions",
+        )
+        slowPathResult.reference?.let(generatedFlows::add)
+        executionMode = SegmentExecutionMode.SLOW
+        if (!slowPathResult.flowResult.success) {
+          val message = "Flow execution failed: ${slowPathResult.flowResult.output}"
           return SegmentResult(
             index = segment.index,
             passed = false,
-            reasoning = "Flow execution failed: ${flowResult.output}",
+            reasoning = message,
+            executionMode = executionMode,
+            actions = actions,
+            generatedFlows = generatedFlows,
+            error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, message),
           )
         }
       }
@@ -75,27 +101,46 @@ class Orchestrator(
 
     // Execute loop
     segment.loop?.let { loop ->
-      val loopResult = executeLoop(loop.action, loop.until, loop.max, appId, platform, navigator)
+      val loopResult = executeLoop(loop.action, loop.until, loop.max, appId, platform, navigator, segment.index)
       return SegmentResult(
         index = segment.index,
         passed = loopResult.satisfied,
         reasoning = loopResult.reasoning,
+        executionMode = SegmentExecutionMode.LOOP,
+        actions = listOf(loop.action),
+        generatedFlows = loopResult.generatedFlows,
+        error = if (loopResult.satisfied) {
+          null
+        } else {
+          ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, loopResult.reasoning)
+        },
       )
     }
 
     // Evaluate assertion
     segment.assertion?.let { assert ->
-      val verdict = evaluateAssertion(assert.description, assert.mode, inspector)
+      val evaluation = evaluateAssertion(assert.description, assert.mode, inspector, segment.index)
       return SegmentResult(
         index = segment.index,
-        passed = verdict.passed,
+        passed = evaluation.verdict.passed,
         assertionMode = assert.mode,
-        reasoning = verdict.reasoning,
+        assertionDescription = assert.description,
+        reasoning = evaluation.verdict.reasoning,
+        executionMode = executionMode,
+        actions = actions,
+        generatedFlows = generatedFlows,
+        evidence = evaluation.evidence,
       )
     }
 
     // Actions only, no assertion — always passes
-    return SegmentResult(index = segment.index, passed = true)
+    return SegmentResult(
+      index = segment.index,
+      passed = true,
+      executionMode = executionMode,
+      actions = actions,
+      generatedFlows = generatedFlows,
+    )
   }
 
   private suspend fun executeFastPath(
@@ -169,9 +214,12 @@ class Orchestrator(
     appId: String,
     platform: Platform,
     navigator: NavigatorAgent,
-  ): FlowResult {
+    segmentIndex: Int,
+    label: String,
+  ): SlowPathResult {
     val yaml = navigator.generate(instructions, appId, platform, context)
-    return session.executeFlow(yaml)
+    val reference = artifactRecorder.saveGeneratedFlow(segmentIndex, label, yaml)
+    return SlowPathResult(session.executeFlow(yaml), reference)
   }
 
   private suspend fun executeLoop(
@@ -181,11 +229,13 @@ class Orchestrator(
     appId: String,
     platform: Platform,
     navigator: NavigatorAgent,
+    segmentIndex: Int,
   ): LoopResult {
     val mapper = InteractionMapper.forPlatform(platform)
     val executor = InteractionExecutor(session, appId)
     val interaction = mapper.map(action)
     var actionsExecuted = 0
+    val generatedFlows = mutableListOf<String>()
 
     repeat(max) {
       if (session.containsText(until)) {
@@ -193,6 +243,7 @@ class Orchestrator(
           satisfied = true,
           iterations = actionsExecuted,
           reasoning = "Text '$until' found after $actionsExecuted iterations",
+          generatedFlows = generatedFlows,
         )
       }
 
@@ -200,12 +251,15 @@ class Orchestrator(
         executor.execute(interaction)
         actionsExecuted += 1
       } else {
-        val flowResult = executeSlowPath(listOf(action), appId, platform, navigator)
-        if (!flowResult.success) {
+        val label = "loop-${actionsExecuted.toString().padStart(3, '0')}"
+        val slowPathResult = executeSlowPath(listOf(action), appId, platform, navigator, segmentIndex, label)
+        slowPathResult.reference?.let(generatedFlows::add)
+        if (!slowPathResult.flowResult.success) {
           return LoopResult(
             satisfied = false,
             iterations = actionsExecuted,
-            reasoning = "Loop flow execution failed: ${flowResult.output}",
+            reasoning = "Loop flow execution failed: ${slowPathResult.flowResult.output}",
+            generatedFlows = generatedFlows,
           )
         }
         actionsExecuted += 1
@@ -218,6 +272,7 @@ class Orchestrator(
         satisfied = true,
         iterations = actionsExecuted,
         reasoning = "Text '$until' found after $actionsExecuted iterations",
+        generatedFlows = generatedFlows,
       )
     }
 
@@ -225,6 +280,7 @@ class Orchestrator(
       satisfied = false,
       iterations = actionsExecuted,
       reasoning = "Text '$until' not found after $actionsExecuted iterations",
+      generatedFlows = generatedFlows,
     )
   }
 
@@ -232,42 +288,70 @@ class Orchestrator(
     description: String,
     mode: AssertMode,
     inspector: InspectorAgent,
-  ): InspectionVerdict = when (mode) {
+    segmentIndex: Int,
+  ): AssertionEvaluation = when (mode) {
     AssertMode.VISIBLE -> {
       val passed = session.containsText(description)
-      InspectionVerdict(
-        passed = passed,
-        reasoning = if (passed) "Text '$description' is visible" else "Text '$description' is not visible",
+      AssertionEvaluation(
+        InspectionVerdict(
+          passed = passed,
+          reasoning = if (passed) "Text '$description' is visible" else "Text '$description' is not visible",
+        ),
       )
     }
 
     AssertMode.FOCUSED -> {
       val passed = session.checkFocused(description)
-      InspectionVerdict(
-        passed = passed,
-        reasoning = if (passed) "Text '$description' is focused" else "Text '$description' is not focused",
+      AssertionEvaluation(
+        InspectionVerdict(
+          passed = passed,
+          reasoning = if (passed) "Text '$description' is focused" else "Text '$description' is not focused",
+        ),
       )
     }
 
     AssertMode.TREE -> {
       val hierarchy = session.captureHierarchy(HierarchyFilter.CONTENT)
-      inspector.evaluateTree(hierarchy, description)
+      val reference = artifactRecorder.saveHierarchy(segmentIndex, hierarchy)
+      AssertionEvaluation(
+        verdict = inspector.evaluateTree(hierarchy, description),
+        evidence = reference?.let { listOf(EvidenceArtifact(EvidenceType.HIERARCHY, it)) } ?: emptyList(),
+      )
     }
 
     AssertMode.VISUAL -> {
-      val tempFile = withContext(Dispatchers.IO) {
-        Files.createTempFile("verity-screenshot-", ".png")
-      }
-      try {
-        session.captureScreenshot(tempFile)
-        inspector.evaluateVisual(tempFile, description)
-      } finally {
-        withContext(NonCancellable + Dispatchers.IO) {
-          Files.deleteIfExists(tempFile)
+      val artifact = artifactRecorder.screenshotPath(segmentIndex)
+      if (artifact != null) {
+        session.captureScreenshot(artifact.path)
+        AssertionEvaluation(
+          verdict = inspector.evaluateVisual(artifact.path, description),
+          evidence = listOf(EvidenceArtifact(EvidenceType.SCREENSHOT, artifact.relativePath)),
+        )
+      } else {
+        val tempFile = withContext(Dispatchers.IO) {
+          Files.createTempFile("verity-screenshot-", ".png")
+        }
+        try {
+          session.captureScreenshot(tempFile)
+          AssertionEvaluation(inspector.evaluateVisual(tempFile, description))
+        } finally {
+          withContext(NonCancellable + Dispatchers.IO) {
+            Files.deleteIfExists(tempFile)
+          }
         }
       }
     }
   }
+
+  private data class SlowPathResult(
+    val flowResult: FlowResult,
+    val reference: String?,
+  )
+
+  private data class AssertionEvaluation(
+    val verdict: InspectionVerdict,
+    val evidence: List<EvidenceArtifact> = emptyList(),
+  )
 
   companion object {
     fun isFastPath(instructions: List<String>, platform: Platform): Boolean {

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
@@ -223,7 +223,13 @@ class Orchestrator(
     label: String,
   ): SlowPathResult {
     val yaml = navigator.generate(instructions, appId, platform, context)
-    val reference = artifactRecorder.saveGeneratedFlow(segmentIndex, label, yaml)
+    val reference = try {
+      artifactRecorder.saveGeneratedFlow(segmentIndex, label, yaml)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (_: Exception) {
+      null
+    }
     return SlowPathResult(session.executeFlow(yaml), reference)
   }
 
@@ -317,7 +323,13 @@ class Orchestrator(
 
     AssertMode.TREE -> {
       val hierarchy = session.captureHierarchy(HierarchyFilter.CONTENT)
-      val reference = artifactRecorder.saveHierarchy(segmentIndex, hierarchy)
+      val reference = try {
+        artifactRecorder.saveHierarchy(segmentIndex, hierarchy)
+      } catch (e: CancellationException) {
+        throw e
+      } catch (_: Exception) {
+        null
+      }
       AssertionEvaluation(
         verdict = inspector.evaluateTree(hierarchy, description),
         evidence = reference?.let { listOf(EvidenceArtifact(EvidenceType.HIERARCHY, it)) } ?: emptyList(),
@@ -325,7 +337,13 @@ class Orchestrator(
     }
 
     AssertMode.VISUAL -> {
-      val artifact = artifactRecorder.screenshotPath(segmentIndex)
+      val artifact = try {
+        artifactRecorder.screenshotPath(segmentIndex)
+      } catch (e: CancellationException) {
+        throw e
+      } catch (_: Exception) {
+        null
+      }
       if (artifact != null) {
         session.captureScreenshot(artifact.path)
         AssertionEvaluation(

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/Orchestrator.kt
@@ -130,6 +130,11 @@ class Orchestrator(
         actions = actions,
         generatedFlows = generatedFlows,
         evidence = evaluation.evidence,
+        error = if (evaluation.verdict.passed) {
+          null
+        } else {
+          ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, evaluation.verdict.reasoning)
+        },
       )
     }
 

--- a/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/OrchestratorResult.kt
+++ b/verity/agent/src/main/kotlin/me/chrisbanes/verity/agent/OrchestratorResult.kt
@@ -1,12 +1,21 @@
 package me.chrisbanes.verity.agent
 
 import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.result.ArtifactError
+import me.chrisbanes.verity.core.result.EvidenceArtifact
+import me.chrisbanes.verity.core.result.SegmentExecutionMode
 
 data class SegmentResult(
   val index: Int,
   val passed: Boolean,
   val assertionMode: AssertMode? = null,
+  val assertionDescription: String? = null,
   val reasoning: String = "",
+  val executionMode: SegmentExecutionMode = SegmentExecutionMode.ASSERTION_ONLY,
+  val actions: List<String> = emptyList(),
+  val generatedFlows: List<String> = emptyList(),
+  val evidence: List<EvidenceArtifact> = emptyList(),
+  val error: ArtifactError? = null,
 )
 
 data class JourneyResult(
@@ -21,4 +30,5 @@ data class LoopResult(
   val satisfied: Boolean,
   val iterations: Int,
   val reasoning: String = "",
+  val generatedFlows: List<String> = emptyList(),
 )

--- a/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
+++ b/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
@@ -16,6 +17,8 @@ import me.chrisbanes.verity.core.model.FlowResult
 import me.chrisbanes.verity.core.model.Journey
 import me.chrisbanes.verity.core.model.JourneyStep
 import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.core.result.EvidenceType
+import me.chrisbanes.verity.core.result.SegmentExecutionMode
 import me.chrisbanes.verity.device.DeviceSession
 
 class OrchestratorTest {
@@ -141,6 +144,43 @@ class OrchestratorTest {
   }
 
   @Test
+  fun `loop slow path fallback records generated flow reference`() = runTest {
+    val session = FakeDeviceSession(
+      containsTextResults = ArrayDeque(listOf(false, true)),
+    )
+    val recorder = RecordingArtifactRecorder()
+    val generatedYaml = flow("- swipe")
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = {
+        NavigatorAgent("unused") { FakeTextAgent { generatedYaml } }
+      },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, _ -> error("unused") },
+        )
+      },
+      artifactRecorder = recorder,
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "loop-flow-metadata",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Loop(action = "navigate to settings page", until = "Settings", max = 2)),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.executionMode).isEqualTo(SegmentExecutionMode.LOOP)
+    assertThat(segment.actions).containsExactly("navigate to settings page")
+    assertThat(segment.generatedFlows).containsExactly("flows/segment-000-loop-000.yaml")
+    assertThat(recorder.generatedFlows).containsExactly("0:loop-000:$generatedYaml")
+  }
+
+  @Test
   fun `run loop reports zero iterations when target already visible`() = runTest {
     val session = FakeDeviceSession(
       containsTextResults = ArrayDeque(listOf(true)),
@@ -194,6 +234,69 @@ class OrchestratorTest {
   }
 
   @Test
+  fun `tree assertion records hierarchy evidence`() = runTest {
+    val session = FakeDeviceSession()
+    val recorder = RecordingArtifactRecorder()
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { """{"passed": true, "reasoning": "Tree matched"}""" } },
+          evaluateVisualContent = { _, _, _ -> error("unused") },
+        )
+      },
+      artifactRecorder = recorder,
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "tree-evidence",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.TREE)),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.evidence.single().type).isEqualTo(EvidenceType.HIERARCHY)
+    assertThat(segment.evidence.single().path).isEqualTo("evidence/segment-000-tree.txt")
+    assertThat(recorder.hierarchies.single()).isEqualTo("[text=Home]\n")
+  }
+
+  @Test
+  fun `visual assertion records screenshot evidence`() = runTest {
+    val session = FakeDeviceSession()
+    val recorder = RecordingArtifactRecorder()
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, _ -> """{"passed": true, "reasoning": "Looks right"}""" },
+        )
+      },
+      artifactRecorder = recorder,
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "visual-evidence",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.VISUAL)),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.evidence.single().type).isEqualTo(EvidenceType.SCREENSHOT)
+    assertThat(segment.evidence.single().path).isEqualTo("evidence/segment-000-visual.png")
+    assertThat(recorder.screenshotRequests).containsExactly(0)
+    assertThat(session.capturedScreenshotPaths).containsExactly(recorder.screenshotPaths.single())
+  }
+
+  @Test
   fun `classifies tap instruction as fast path on mobile`() {
     val actions = listOf("tap Settings")
     val isFastPath = Orchestrator.isFastPath(actions, Platform.ANDROID_MOBILE)
@@ -234,6 +337,81 @@ class OrchestratorTest {
 
     val result = orchestrator.run(journey)
     assertThat(result.passed).isTrue()
+  }
+
+  @Test
+  fun `fast path segment records execution mode and source actions`() = runTest {
+    val session = FakeDeviceSession(
+      containsTextResults = ArrayDeque(listOf(true)),
+    )
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = {
+        NavigatorAgent("unused") { FakeTextAgent { error("navigator should not be called on fast path") } }
+      },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, _ -> error("unused") },
+        )
+      },
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "fast-metadata",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Action(instruction = "tap Settings")),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.executionMode).isEqualTo(SegmentExecutionMode.FAST)
+    assertThat(segment.actions).containsExactly("tap Settings")
+    assertThat(segment.generatedFlows).isEmpty()
+  }
+
+  @Test
+  fun `slow path segment records generated flow reference before execution`() = runTest {
+    val recorder = RecordingArtifactRecorder()
+    val generatedYaml = flow("- tapOn: \"Settings\"")
+    val session = FakeDeviceSession(
+      onExecuteFlow = { yaml ->
+        if (yaml == generatedYaml) {
+          assertThat(recorder.generatedFlows).containsExactly("0:actions:$generatedYaml")
+        }
+      },
+    )
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = {
+        NavigatorAgent("unused") { FakeTextAgent { generatedYaml } }
+      },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, _ -> error("unused") },
+        )
+      },
+      artifactRecorder = recorder,
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "slow-metadata",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Action(instruction = "navigate to settings page")),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.executionMode).isEqualTo(SegmentExecutionMode.SLOW)
+    assertThat(segment.actions).containsExactly("navigate to settings page")
+    assertThat(segment.generatedFlows).containsExactly("flows/segment-000-actions.yaml")
+    assertThat(recorder.generatedFlows).containsExactly("0:actions:$generatedYaml")
+    assertThat(session.executedFlows).containsExactly(LAUNCH_FLOW, generatedYaml)
   }
 
   @Test
@@ -500,21 +678,54 @@ class OrchestratorTest {
 
   private class FakeDeviceSession(
     private val containsTextResults: ArrayDeque<Boolean> = ArrayDeque(),
+    private val onExecuteFlow: (String) -> Unit = {},
   ) : DeviceSession {
     override val platform: Platform = Platform.ANDROID_MOBILE
     val executedFlows = mutableListOf<String>()
+    val capturedScreenshotPaths = mutableListOf<Path>()
 
     override suspend fun executeFlow(yaml: String): FlowResult {
+      onExecuteFlow(yaml)
       executedFlows += yaml
       return FlowResult(success = true)
     }
     override suspend fun pressKey(keyName: String) = Unit
     override suspend fun captureHierarchyTree(): HierarchyNode = HierarchyNode(attributes = mapOf("text" to "Home"))
-    override suspend fun captureScreenshot(output: Path) = Unit
+    override suspend fun captureScreenshot(output: Path) {
+      capturedScreenshotPaths.add(output)
+      Files.write(output, byteArrayOf(1, 2, 3))
+    }
     override suspend fun shell(command: String): String = ""
     override suspend fun waitForAnimationToEnd() = Unit
     override suspend fun containsText(text: String, ignoreCase: Boolean): Boolean = containsTextResults.removeFirstOrNull() ?: false
 
     override fun close() = Unit
+  }
+
+  private class RecordingArtifactRecorder : JourneyArtifactRecorder {
+    val generatedFlows = mutableListOf<String>()
+    val hierarchies = mutableListOf<String>()
+    val screenshotRequests = mutableListOf<Int>()
+    val screenshotPaths = mutableListOf<Path>()
+
+    override suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String {
+      generatedFlows += "$segmentIndex:$label:$yaml"
+      return "flows/segment-${segmentIndex.toString().padStart(3, '0')}-$label.yaml"
+    }
+
+    override suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String {
+      hierarchies += hierarchy
+      return "evidence/segment-${segmentIndex.toString().padStart(3, '0')}-tree.txt"
+    }
+
+    override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact {
+      screenshotRequests += segmentIndex
+      val path = Files.createTempFile("verity-visual-test", ".png")
+      screenshotPaths.add(path)
+      return JourneyScreenshotArtifact(
+        path = path,
+        relativePath = "evidence/segment-${segmentIndex.toString().padStart(3, '0')}-visual.png",
+      )
+    }
   }
 }

--- a/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
+++ b/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
@@ -11,6 +11,7 @@ import assertk.assertions.isTrue
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
 import me.chrisbanes.verity.core.hierarchy.HierarchyNode
 import me.chrisbanes.verity.core.model.AssertMode
@@ -553,6 +554,39 @@ class OrchestratorTest {
     assertThat(captureAttempts.size).isEqualTo(2)
     assertThat(captureAttempts.first()).isEqualTo(artifactPath)
     assertThat(session.capturedScreenshotPaths).containsExactly(captureAttempts.last())
+  }
+
+  @Test
+  fun `visual evaluator failure after artifact capture is not retried with temp screenshot`() = runTest {
+    val artifactPath = Files.createTempDirectory("verity-visual-evaluator-failure").resolve("artifact.png")
+    val evaluatedPaths = mutableListOf<Path>()
+    val orchestrator = Orchestrator(
+      session = FakeDeviceSession(),
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, screenshotPath ->
+            evaluatedPaths.add(screenshotPath)
+            error("visual evaluator failed")
+          },
+        )
+      },
+      artifactRecorder = StaticScreenshotArtifactRecorder(artifactPath),
+    )
+
+    assertFailsWith<IllegalStateException> {
+      orchestrator.run(
+        Journey(
+          name = "visual-evaluator-failure",
+          app = APP_ID,
+          platform = Platform.ANDROID_MOBILE,
+          steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.VISUAL)),
+        ),
+      )
+    }
+
+    assertThat(evaluatedPaths).containsExactly(artifactPath)
   }
 
   @Test

--- a/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
+++ b/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
@@ -17,6 +17,7 @@ import me.chrisbanes.verity.core.model.FlowResult
 import me.chrisbanes.verity.core.model.Journey
 import me.chrisbanes.verity.core.model.JourneyStep
 import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.core.result.ArtifactErrorKind
 import me.chrisbanes.verity.core.result.EvidenceType
 import me.chrisbanes.verity.core.result.SegmentExecutionMode
 import me.chrisbanes.verity.device.DeviceSession
@@ -230,7 +231,10 @@ class OrchestratorTest {
     val result = orchestrator.run(journey)
 
     assertThat(result.passed).isFalse()
-    assertThat(result.segments.single().reasoning).isEqualTo("Text 'Home' is not visible")
+    val segment = result.segments.single()
+    assertThat(segment.reasoning).isEqualTo("Text 'Home' is not visible")
+    assertThat(segment.error?.kind).isEqualTo(ArtifactErrorKind.JOURNEY_FAILURE)
+    assertThat(segment.error?.message).isEqualTo("Text 'Home' is not visible")
   }
 
   @Test
@@ -266,34 +270,39 @@ class OrchestratorTest {
 
   @Test
   fun `visual assertion records screenshot evidence`() = runTest {
-    val session = FakeDeviceSession()
-    val recorder = RecordingArtifactRecorder()
-    val orchestrator = Orchestrator(
-      session = session,
-      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
-      inspectorFactory = {
-        InspectorAgent(
-          treeAgentFactory = { FakeTextAgent { error("unused") } },
-          evaluateVisualContent = { _, _, _ -> """{"passed": true, "reasoning": "Looks right"}""" },
-        )
-      },
-      artifactRecorder = recorder,
-    )
+    val screenshotDirectory = Files.createTempDirectory("verity-visual-test")
+    try {
+      val session = FakeDeviceSession()
+      val recorder = RecordingArtifactRecorder(screenshotDirectory)
+      val orchestrator = Orchestrator(
+        session = session,
+        navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+        inspectorFactory = {
+          InspectorAgent(
+            treeAgentFactory = { FakeTextAgent { error("unused") } },
+            evaluateVisualContent = { _, _, _ -> """{"passed": true, "reasoning": "Looks right"}""" },
+          )
+        },
+        artifactRecorder = recorder,
+      )
 
-    val result = orchestrator.run(
-      Journey(
-        name = "visual-evidence",
-        app = APP_ID,
-        platform = Platform.ANDROID_MOBILE,
-        steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.VISUAL)),
-      ),
-    )
+      val result = orchestrator.run(
+        Journey(
+          name = "visual-evidence",
+          app = APP_ID,
+          platform = Platform.ANDROID_MOBILE,
+          steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.VISUAL)),
+        ),
+      )
 
-    val segment = result.segments.single()
-    assertThat(segment.evidence.single().type).isEqualTo(EvidenceType.SCREENSHOT)
-    assertThat(segment.evidence.single().path).isEqualTo("evidence/segment-000-visual.png")
-    assertThat(recorder.screenshotRequests).containsExactly(0)
-    assertThat(session.capturedScreenshotPaths).containsExactly(recorder.screenshotPaths.single())
+      val segment = result.segments.single()
+      assertThat(segment.evidence.single().type).isEqualTo(EvidenceType.SCREENSHOT)
+      assertThat(segment.evidence.single().path).isEqualTo("evidence/segment-000-visual.png")
+      assertThat(recorder.screenshotRequests).containsExactly(0)
+      assertThat(session.capturedScreenshotPaths).containsExactly(recorder.screenshotPaths.single())
+    } finally {
+      deleteRecursively(screenshotDirectory)
+    }
   }
 
   @Test
@@ -670,12 +679,6 @@ class OrchestratorTest {
     assertThat(session.executedFlows).containsExactly(LAUNCH_FLOW, flow("- swipe:\n    direction: UP"))
   }
 
-  private companion object {
-    const val APP_ID = "com.example.app"
-    const val LAUNCH_FLOW = "appId: $APP_ID\n---\n- launchApp"
-    fun flow(command: String) = "appId: $APP_ID\n---\n$command"
-  }
-
   private class FakeDeviceSession(
     private val containsTextResults: ArrayDeque<Boolean> = ArrayDeque(),
     private val onExecuteFlow: (String) -> Unit = {},
@@ -702,7 +705,9 @@ class OrchestratorTest {
     override fun close() = Unit
   }
 
-  private class RecordingArtifactRecorder : JourneyArtifactRecorder {
+  private class RecordingArtifactRecorder(
+    private val screenshotDirectory: Path? = null,
+  ) : JourneyArtifactRecorder {
     val generatedFlows = mutableListOf<String>()
     val hierarchies = mutableListOf<String>()
     val screenshotRequests = mutableListOf<Int>()
@@ -720,12 +725,29 @@ class OrchestratorTest {
 
     override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact {
       screenshotRequests += segmentIndex
-      val path = Files.createTempFile("verity-visual-test", ".png")
+      val path = if (screenshotDirectory != null) {
+        Files.createTempFile(screenshotDirectory, "verity-visual-test", ".png")
+      } else {
+        Files.createTempFile("verity-visual-test", ".png")
+      }
       screenshotPaths.add(path)
       return JourneyScreenshotArtifact(
         path = path,
         relativePath = "evidence/segment-${segmentIndex.toString().padStart(3, '0')}-visual.png",
       )
+    }
+  }
+
+  private companion object {
+    const val APP_ID = "com.example.app"
+    const val LAUNCH_FLOW = "appId: $APP_ID\n---\n- launchApp"
+    fun flow(command: String) = "appId: $APP_ID\n---\n$command"
+
+    fun deleteRecursively(path: Path) {
+      if (!Files.exists(path)) return
+      Files.walk(path).use { paths ->
+        paths.sorted(Comparator.reverseOrder()).forEach(Files::deleteIfExists)
+      }
     }
   }
 }

--- a/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
+++ b/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
@@ -424,6 +424,95 @@ class OrchestratorTest {
   }
 
   @Test
+  fun `slow path recorder failure does not prevent flow execution`() = runTest {
+    val generatedYaml = flow("- tapOn: \"Settings\"")
+    val session = FakeDeviceSession()
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { generatedYaml } } },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, _ -> error("unused") },
+        )
+      },
+      artifactRecorder = ThrowingArtifactRecorder(),
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "slow-recorder-failure",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Action(instruction = "navigate to settings page")),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.passed).isTrue()
+    assertThat(segment.generatedFlows).isEmpty()
+    assertThat(session.executedFlows).containsExactly(LAUNCH_FLOW, generatedYaml)
+  }
+
+  @Test
+  fun `tree recorder failure does not fail passing assertion`() = runTest {
+    val orchestrator = Orchestrator(
+      session = FakeDeviceSession(),
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { """{"passed": true, "reasoning": "Tree matched"}""" } },
+          evaluateVisualContent = { _, _, _ -> error("unused") },
+        )
+      },
+      artifactRecorder = ThrowingArtifactRecorder(),
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "tree-recorder-failure",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.TREE)),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.passed).isTrue()
+    assertThat(segment.evidence).isEmpty()
+  }
+
+  @Test
+  fun `visual recorder failure does not fail passing assertion`() = runTest {
+    val session = FakeDeviceSession()
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, _ -> """{"passed": true, "reasoning": "Looks right"}""" },
+        )
+      },
+      artifactRecorder = ThrowingArtifactRecorder(),
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "visual-recorder-failure",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.VISUAL)),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.passed).isTrue()
+    assertThat(segment.evidence).isEmpty()
+    assertThat(session.capturedScreenshotPaths.size).isEqualTo(1)
+  }
+
+  @Test
   fun `fast path scrolls to find off-screen target then taps`() = runTest {
     // First containsText: not visible. After scroll: visible.
     val session = FakeDeviceSession(
@@ -736,6 +825,14 @@ class OrchestratorTest {
         relativePath = "evidence/segment-${segmentIndex.toString().padStart(3, '0')}-visual.png",
       )
     }
+  }
+
+  private class ThrowingArtifactRecorder : JourneyArtifactRecorder {
+    override suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String = error("artifact unavailable")
+
+    override suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String = error("artifact unavailable")
+
+    override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact = error("artifact unavailable")
   }
 
   private companion object {

--- a/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
+++ b/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isFalse
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
@@ -515,13 +516,13 @@ class OrchestratorTest {
   }
 
   @Test
-  fun `visual artifact capture failure falls back to temp screenshot without evidence`() = runTest {
+  fun `visual artifact capture IOException falls back to temp screenshot without evidence`() = runTest {
     val artifactPath = Files.createTempDirectory("verity-unwritable-artifact").resolve("artifact.png")
     val captureAttempts = mutableListOf<Path>()
     val session = FakeDeviceSession(
       onCaptureScreenshot = { path ->
         captureAttempts.add(path)
-        if (path == artifactPath) error("artifact path unavailable")
+        if (path == artifactPath) throw IOException("artifact path unavailable")
       },
     )
     val orchestrator = Orchestrator(
@@ -554,6 +555,41 @@ class OrchestratorTest {
     assertThat(captureAttempts.size).isEqualTo(2)
     assertThat(captureAttempts.first()).isEqualTo(artifactPath)
     assertThat(session.capturedScreenshotPaths).containsExactly(captureAttempts.last())
+  }
+
+  @Test
+  fun `visual artifact capture device failure is not retried with temp screenshot`() = runTest {
+    val artifactPath = Files.createTempDirectory("verity-visual-device-failure").resolve("artifact.png")
+    val captureAttempts = mutableListOf<Path>()
+    val orchestrator = Orchestrator(
+      session = FakeDeviceSession(
+        onCaptureScreenshot = { path ->
+          captureAttempts.add(path)
+          if (path == artifactPath) error("device screenshot failed")
+        },
+      ),
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, _ -> error("visual evaluator should not run") },
+        )
+      },
+      artifactRecorder = StaticScreenshotArtifactRecorder(artifactPath),
+    )
+
+    assertFailsWith<IllegalStateException> {
+      orchestrator.run(
+        Journey(
+          name = "visual-device-failure",
+          app = APP_ID,
+          platform = Platform.ANDROID_MOBILE,
+          steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.VISUAL)),
+        ),
+      )
+    }
+
+    assertThat(captureAttempts).containsExactly(artifactPath)
   }
 
   @Test

--- a/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
+++ b/verity/agent/src/test/kotlin/me/chrisbanes/verity/agent/OrchestratorTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import java.nio.file.Files
@@ -513,6 +514,48 @@ class OrchestratorTest {
   }
 
   @Test
+  fun `visual artifact capture failure falls back to temp screenshot without evidence`() = runTest {
+    val artifactPath = Files.createTempDirectory("verity-unwritable-artifact").resolve("artifact.png")
+    val captureAttempts = mutableListOf<Path>()
+    val session = FakeDeviceSession(
+      onCaptureScreenshot = { path ->
+        captureAttempts.add(path)
+        if (path == artifactPath) error("artifact path unavailable")
+      },
+    )
+    val orchestrator = Orchestrator(
+      session = session,
+      navigatorFactory = { NavigatorAgent("unused") { FakeTextAgent { error("unused") } } },
+      inspectorFactory = {
+        InspectorAgent(
+          treeAgentFactory = { FakeTextAgent { error("unused") } },
+          evaluateVisualContent = { _, _, screenshotPath ->
+            assertThat(screenshotPath).isNotEqualTo(artifactPath)
+            """{"passed": true, "reasoning": "Looks right"}"""
+          },
+        )
+      },
+      artifactRecorder = StaticScreenshotArtifactRecorder(artifactPath),
+    )
+
+    val result = orchestrator.run(
+      Journey(
+        name = "visual-artifact-capture-failure",
+        app = APP_ID,
+        platform = Platform.ANDROID_MOBILE,
+        steps = listOf(JourneyStep.Assert(description = "Home is visible", mode = AssertMode.VISUAL)),
+      ),
+    )
+
+    val segment = result.segments.single()
+    assertThat(segment.passed).isTrue()
+    assertThat(segment.evidence).isEmpty()
+    assertThat(captureAttempts.size).isEqualTo(2)
+    assertThat(captureAttempts.first()).isEqualTo(artifactPath)
+    assertThat(session.capturedScreenshotPaths).containsExactly(captureAttempts.last())
+  }
+
+  @Test
   fun `fast path scrolls to find off-screen target then taps`() = runTest {
     // First containsText: not visible. After scroll: visible.
     val session = FakeDeviceSession(
@@ -771,6 +814,7 @@ class OrchestratorTest {
   private class FakeDeviceSession(
     private val containsTextResults: ArrayDeque<Boolean> = ArrayDeque(),
     private val onExecuteFlow: (String) -> Unit = {},
+    private val onCaptureScreenshot: (Path) -> Unit = {},
   ) : DeviceSession {
     override val platform: Platform = Platform.ANDROID_MOBILE
     val executedFlows = mutableListOf<String>()
@@ -784,6 +828,7 @@ class OrchestratorTest {
     override suspend fun pressKey(keyName: String) = Unit
     override suspend fun captureHierarchyTree(): HierarchyNode = HierarchyNode(attributes = mapOf("text" to "Home"))
     override suspend fun captureScreenshot(output: Path) {
+      onCaptureScreenshot(output)
       capturedScreenshotPaths.add(output)
       Files.write(output, byteArrayOf(1, 2, 3))
     }
@@ -833,6 +878,15 @@ class OrchestratorTest {
     override suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String = error("artifact unavailable")
 
     override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact = error("artifact unavailable")
+  }
+
+  private class StaticScreenshotArtifactRecorder(
+    private val path: Path,
+  ) : JourneyArtifactRecorder {
+    override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact = JourneyScreenshotArtifact(
+      path = path,
+      relativePath = "evidence/segment-${segmentIndex.toString().padStart(3, '0')}-visual.png",
+    )
   }
 
   private companion object {

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/ResolvedProjectConfig.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/ResolvedProjectConfig.kt
@@ -95,6 +95,12 @@ fun validateOutputDirectory(path: File) {
   }
 }
 
+fun ResolvedProjectConfig.toRunArtifactMetadata(): RunArtifactMetadata = RunArtifactMetadata(
+  provider = provider.name,
+  navigatorModel = navigatorModel.id,
+  inspectorModel = inspectorModel.id,
+)
+
 val Platform.serialName: String
   get() = when (this) {
     Platform.ANDROID_TV -> "android-tv"

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt
@@ -1,8 +1,11 @@
 package me.chrisbanes.verity.cli
 
 import java.io.File
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.time.Clock
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -26,10 +29,10 @@ class RunArtifactWriter(
 
   suspend fun createRun(suiteSlugSource: String): RunArtifactDirectory = withContext(Dispatchers.IO) {
     val timestamp = DATE_FORMAT.format(clock.instant().atZone(ZoneOffset.UTC))
-    val directory = outputRoot.toPath()
-      .resolve("runs")
-      .resolve("$timestamp-${slugArtifactName(suiteSlugSource, "run")}")
-    Files.createDirectories(directory)
+    val runsDirectory = outputRoot.toPath().resolve("runs")
+    Files.createDirectories(runsDirectory)
+    val baseName = "$timestamp-${slugArtifactName(suiteSlugSource, "run")}"
+    val directory = createUniqueDirectory(runsDirectory, baseName)
     RunArtifactDirectory(directory = directory, json = json)
   }
 
@@ -48,13 +51,13 @@ class RunArtifactDirectory(
   }
 
   suspend fun writeJourneyResult(path: String, result: JourneyArtifactResult) = withContext(Dispatchers.IO) {
-    val target = directory.resolve(path)
+    val target = resolveArtifactPath(directory, path)
     Files.createDirectories(target.parent)
-    Files.writeString(target, json.encodeToString(JourneyArtifactResult.serializer(), result))
+    writeJsonAtomically(target, json.encodeToString(JourneyArtifactResult.serializer(), result))
   }
 
   suspend fun writeSummary(summary: SuiteArtifactSummary) = withContext(Dispatchers.IO) {
-    Files.writeString(directory.resolve("summary.json"), json.encodeToString(SuiteArtifactSummary.serializer(), summary))
+    writeJsonAtomically(resolveArtifactPath(directory, "summary.json"), json.encodeToString(SuiteArtifactSummary.serializer(), summary))
   }
 }
 
@@ -63,8 +66,8 @@ class JourneyRunArtifactRecorder(
   private val key: String,
 ) : JourneyArtifactRecorder {
   override suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String = withContext(Dispatchers.IO) {
-    val relative = "flows/$key/segment-${segmentIndex.toString().padStart(3, '0')}-$label.yaml"
-    val target = directory.resolve(relative)
+    val relative = "flows/$key/segment-${segmentIndex.toString().padStart(3, '0')}-${slugArtifactName(label, "flow")}.yaml"
+    val target = resolveArtifactPath(directory, relative)
     Files.createDirectories(target.parent)
     Files.writeString(target, yaml)
     relative
@@ -72,7 +75,7 @@ class JourneyRunArtifactRecorder(
 
   override suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String = withContext(Dispatchers.IO) {
     val relative = "evidence/$key/segment-${segmentIndex.toString().padStart(3, '0')}-tree.txt"
-    val target = directory.resolve(relative)
+    val target = resolveArtifactPath(directory, relative)
     Files.createDirectories(target.parent)
     Files.writeString(target, hierarchy)
     relative
@@ -80,7 +83,7 @@ class JourneyRunArtifactRecorder(
 
   override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact = withContext(Dispatchers.IO) {
     val relative = "evidence/$key/segment-${segmentIndex.toString().padStart(3, '0')}-visual.png"
-    val target = directory.resolve(relative)
+    val target = resolveArtifactPath(directory, relative)
     Files.createDirectories(target.parent)
     JourneyScreenshotArtifact(path = target, relativePath = relative)
   }
@@ -89,4 +92,41 @@ class JourneyRunArtifactRecorder(
 internal fun slugArtifactName(value: String, fallback: String): String {
   val slug = value.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
   return slug.ifEmpty { fallback }
+}
+
+private fun createUniqueDirectory(parent: Path, baseName: String): Path {
+  var attempt = 1
+  while (true) {
+    val name = if (attempt == 1) baseName else "$baseName-$attempt"
+    val candidate = parent.resolve(name)
+    try {
+      return Files.createDirectory(candidate)
+    } catch (_: FileAlreadyExistsException) {
+      attempt += 1
+    }
+  }
+}
+
+private fun resolveArtifactPath(directory: Path, relative: String): Path {
+  val relativePath = Path.of(relative)
+  require(!relativePath.isAbsolute) { "Artifact path must be relative: $relative" }
+
+  val root = directory.normalize()
+  val target = root.resolve(relativePath).normalize()
+  require(target.startsWith(root)) { "Artifact path escapes run directory: $relative" }
+  return target
+}
+
+private fun writeJsonAtomically(target: Path, json: String) {
+  val temp = Files.createTempFile(target.parent, ".${target.fileName}", ".tmp")
+  try {
+    Files.writeString(temp, json)
+    try {
+      Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+    } catch (_: AtomicMoveNotSupportedException) {
+      Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING)
+    }
+  } finally {
+    Files.deleteIfExists(temp)
+  }
 }

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt
@@ -1,0 +1,92 @@
+package me.chrisbanes.verity.cli
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import me.chrisbanes.verity.agent.JourneyArtifactRecorder
+import me.chrisbanes.verity.agent.JourneyScreenshotArtifact
+import me.chrisbanes.verity.core.result.JourneyArtifactResult
+import me.chrisbanes.verity.core.result.SuiteArtifactSummary
+
+class RunArtifactWriter(
+  private val outputRoot: File,
+  private val clock: Clock = Clock.systemUTC(),
+) {
+  private val json = Json {
+    prettyPrint = true
+    encodeDefaults = true
+    explicitNulls = false
+  }
+
+  suspend fun createRun(suiteSlugSource: String): RunArtifactDirectory = withContext(Dispatchers.IO) {
+    val timestamp = DATE_FORMAT.format(clock.instant().atZone(ZoneOffset.UTC))
+    val directory = outputRoot.toPath()
+      .resolve("runs")
+      .resolve("$timestamp-${slugArtifactName(suiteSlugSource, "run")}")
+    Files.createDirectories(directory)
+    RunArtifactDirectory(directory = directory, json = json)
+  }
+
+  private companion object {
+    val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+  }
+}
+
+class RunArtifactDirectory(
+  val directory: Path,
+  private val json: Json,
+) {
+  fun journey(index: Int, name: String): JourneyRunArtifactRecorder {
+    val key = "${index.toString().padStart(3, '0')}-${slugArtifactName(name, "journey")}"
+    return JourneyRunArtifactRecorder(directory = directory, key = key)
+  }
+
+  suspend fun writeJourneyResult(path: String, result: JourneyArtifactResult) = withContext(Dispatchers.IO) {
+    val target = directory.resolve(path)
+    Files.createDirectories(target.parent)
+    Files.writeString(target, json.encodeToString(JourneyArtifactResult.serializer(), result))
+  }
+
+  suspend fun writeSummary(summary: SuiteArtifactSummary) = withContext(Dispatchers.IO) {
+    Files.writeString(directory.resolve("summary.json"), json.encodeToString(SuiteArtifactSummary.serializer(), summary))
+  }
+}
+
+class JourneyRunArtifactRecorder(
+  private val directory: Path,
+  private val key: String,
+) : JourneyArtifactRecorder {
+  override suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String = withContext(Dispatchers.IO) {
+    val relative = "flows/$key/segment-${segmentIndex.toString().padStart(3, '0')}-$label.yaml"
+    val target = directory.resolve(relative)
+    Files.createDirectories(target.parent)
+    Files.writeString(target, yaml)
+    relative
+  }
+
+  override suspend fun saveHierarchy(segmentIndex: Int, hierarchy: String): String = withContext(Dispatchers.IO) {
+    val relative = "evidence/$key/segment-${segmentIndex.toString().padStart(3, '0')}-tree.txt"
+    val target = directory.resolve(relative)
+    Files.createDirectories(target.parent)
+    Files.writeString(target, hierarchy)
+    relative
+  }
+
+  override suspend fun screenshotPath(segmentIndex: Int): JourneyScreenshotArtifact = withContext(Dispatchers.IO) {
+    val relative = "evidence/$key/segment-${segmentIndex.toString().padStart(3, '0')}-visual.png"
+    val target = directory.resolve(relative)
+    Files.createDirectories(target.parent)
+    JourneyScreenshotArtifact(path = target, relativePath = relative)
+  }
+}
+
+internal fun slugArtifactName(value: String, fallback: String): String {
+  val slug = value.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
+  return slug.ifEmpty { fallback }
+}

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunArtifacts.kt
@@ -63,8 +63,10 @@ class RunArtifactDirectory(
 
 class JourneyRunArtifactRecorder(
   private val directory: Path,
-  private val key: String,
+  val key: String,
 ) : JourneyArtifactRecorder {
+  val resultPath: String get() = "journeys/$key.json"
+
   override suspend fun saveGeneratedFlow(segmentIndex: Int, label: String, yaml: String): String = withContext(Dispatchers.IO) {
     val relative = "flows/$key/segment-${segmentIndex.toString().padStart(3, '0')}-${slugArtifactName(label, "flow")}.yaml"
     val target = resolveArtifactPath(directory, relative)

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -55,8 +55,15 @@ data class ResolvedJourneyResult(
   val result: JourneyResult,
 )
 
+data class RunArtifactMetadata(
+  val provider: String,
+  val navigatorModel: String,
+  val inspectorModel: String,
+)
+
 data class SuiteRunResult(
   val results: List<ResolvedJourneyResult>,
+  val metadata: RunArtifactMetadata? = null,
 ) {
   val passed: Boolean get() = results.all { it.result.passed }
   val passedCount: Int get() = results.count { it.result.passed }
@@ -147,6 +154,7 @@ class RunCommand(
         cli = cliOptions,
       )
     }
+    val metadata = resolved.toRunArtifactMetadata()
     validateOutputDirectory(resolved.outputPath)
 
     val path = try {
@@ -155,7 +163,7 @@ class RunCommand(
       val message = e.message ?: "Invalid journey path"
       val inputPath = journeyPath ?: resolved.configuredJourneysPath?.path ?: "<unresolved>"
       val runArtifacts = createRunArtifactsOrExit(resolved.outputPath, journeyPath ?: resolved.configuredJourneysPath?.path ?: "run")
-      writeParserFailureSummary(runArtifacts, inputPath, message)
+      writeParserFailureSummary(runArtifacts, inputPath, message, metadata)
       throw CliktError(message, statusCode = EXIT_INPUT)
     }
     val runArtifacts = createRunArtifactsOrExit(resolved.outputPath, path.nameWithoutExtension.ifEmpty { path.name })
@@ -169,7 +177,7 @@ class RunCommand(
       throw e
     } catch (e: Exception) {
       val message = e.message ?: "Failed to resolve journeys"
-      writeParserFailureSummary(runArtifacts, path.path, message)
+      writeParserFailureSummary(runArtifacts, path.path, message, metadata)
       throw CliktError(message, statusCode = EXIT_INPUT)
     }
 
@@ -209,11 +217,11 @@ class RunCommand(
       throw e
     } catch (e: JourneyExecutionFailure) {
       val message = e.message ?: "Journey suite failed"
-      writeJourneyFailureSummary(runArtifacts, path.path, message, journeys)
+      writeJourneyFailureSummary(runArtifacts, path.path, message, journeys, metadata)
       throw CliktError(message, statusCode = EXIT_JOURNEY)
     } catch (e: Exception) {
       val message = e.message ?: "Journey suite setup failed"
-      writeSetupFailureSummary(runArtifacts, path.path, message)
+      writeSetupFailureSummary(runArtifacts, path.path, message, metadata = metadata)
       throw CliktError(message, statusCode = EXIT_SETUP)
     }
 
@@ -224,7 +232,7 @@ class RunCommand(
       throw e
     } catch (e: Exception) {
       val message = e.message ?: "Failed to write run artifacts"
-      writeSetupFailureSummary(runArtifacts, path.path, message, suiteResult)
+      writeSetupFailureSummary(runArtifacts, path.path, message, suiteResult, metadata)
       throw CliktError(message, statusCode = EXIT_SETUP)
     }
 
@@ -343,6 +351,7 @@ class RunCommand(
     runArtifacts: RunArtifactDirectory,
     inputPath: String,
     message: String,
+    metadata: RunArtifactMetadata? = null,
   ) {
     runArtifacts.writeSummary(
       SuiteArtifactSummary(
@@ -354,6 +363,9 @@ class RunCommand(
         passed = 0,
         failed = 0,
         error = ArtifactError(ArtifactErrorKind.PARSER_FAILURE, message),
+        provider = metadata?.provider,
+        navigatorModel = metadata?.navigatorModel,
+        inspectorModel = metadata?.inspectorModel,
       ),
     )
   }
@@ -363,7 +375,9 @@ class RunCommand(
     inputPath: String,
     message: String,
     suiteResult: SuiteRunResult? = null,
+    metadata: RunArtifactMetadata? = null,
   ) {
+    val summaryMetadata = suiteResult?.metadata ?: metadata
     try {
       runArtifacts.writeSummary(
         SuiteArtifactSummary(
@@ -384,6 +398,9 @@ class RunCommand(
           } ?: emptyList(),
           error = ArtifactError(ArtifactErrorKind.SETUP_FAILURE, message),
           platform = suiteResult?.results?.firstOrNull()?.resolvedJourney?.journey?.platform,
+          provider = summaryMetadata?.provider,
+          navigatorModel = summaryMetadata?.navigatorModel,
+          inspectorModel = summaryMetadata?.inspectorModel,
         ),
       )
     } catch (e: CancellationException) {
@@ -398,6 +415,7 @@ class RunCommand(
     inputPath: String,
     message: String,
     journeys: List<ResolvedJourney>,
+    metadata: RunArtifactMetadata? = null,
   ) {
     try {
       runArtifacts.writeSummary(
@@ -419,6 +437,9 @@ class RunCommand(
           },
           error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, message),
           platform = journeys.firstOrNull()?.journey?.platform,
+          provider = metadata?.provider,
+          navigatorModel = metadata?.navigatorModel,
+          inspectorModel = metadata?.inspectorModel,
         ),
       )
     } catch (e: CancellationException) {
@@ -458,6 +479,9 @@ class RunCommand(
           ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "Journey suite failed")
         },
         platform = suiteResult.results.firstOrNull()?.resolvedJourney?.journey?.platform,
+        provider = suiteResult.metadata?.provider,
+        navigatorModel = suiteResult.metadata?.navigatorModel,
+        inspectorModel = suiteResult.metadata?.inspectorModel,
       ),
     )
   }
@@ -618,7 +642,7 @@ class RunCommand(
             artifactRecorder = artifactRecorder,
           )
           orchestrator.run(resolved.journey)
-        }
+        }.copy(metadata = resolved.toRunArtifactMetadata())
       } catch (e: CancellationException) {
         throw e
       } catch (e: Exception) {

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -73,6 +73,7 @@ data class SuiteRunResult(
 class RunCommand(
   private val loadJourney: (File, AssertionStrategy) -> Journey = JourneyLoader::fromFile,
   private val listJourneyFiles: (File) -> List<File> = JourneyLoader::listJourneyFiles,
+  private val loadConfig: (File) -> VerityConfig = VerityConfig::loadOrDefault,
   private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
   private val dryRunSuiteRunner: (suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport)? = null,
   private val clock: Clock = Clock.systemUTC(),
@@ -144,15 +145,19 @@ class RunCommand(
   override fun run() = runBlocking {
     val parent = currentContext.parent?.command as Verity
 
-    val config = VerityConfig.loadOrDefault(File("verity/config.yaml"))
+    val config = loadConfig(File("verity/config.yaml"))
     val cliOptions = parent.projectCliOptions()
-    val resolved = if (dryRun) {
-      resolveDryRunProjectConfig(config, cliOptions)
-    } else {
-      ResolvedProjectConfig.resolve(
-        config = config,
-        cli = cliOptions,
-      )
+    val resolved = try {
+      if (dryRun) {
+        resolveDryRunProjectConfig(config, cliOptions)
+      } else {
+        ResolvedProjectConfig.resolve(
+          config = config,
+          cli = cliOptions,
+        )
+      }
+    } catch (e: IllegalArgumentException) {
+      throw CliktError(e.message ?: "Invalid project configuration", statusCode = EXIT_SETUP)
     }
     val metadata = resolved.toRunArtifactMetadata()
     try {

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -389,7 +389,9 @@ class RunCommand(
     } catch (e: CancellationException) {
       throw e
     } catch (e: Exception) {
-      throw CliktError(e.message ?: "Failed to write parser failure summary", statusCode = EXIT_SETUP)
+      val artifactMessage = e.message ?: "Failed to write parser failure summary"
+      writeSetupFailureSummary(runArtifacts, inputPath, artifactMessage, metadata = metadata)
+      throw CliktError(artifactMessage, statusCode = EXIT_SETUP)
     }
   }
 

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -6,7 +6,6 @@ import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.flag
@@ -147,12 +146,18 @@ class RunCommand(
     }
     validateOutputDirectory(resolved.outputPath)
 
+    val artifactWriter = RunArtifactWriter(resolved.outputPath, clock)
     val path = try {
       resolveRunJourneyFile(journeyPath, resolved.configuredJourneysPath)
     } catch (e: IllegalArgumentException) {
-      throw UsageError(e.message ?: "Invalid journey path")
+      val message = e.message ?: "Invalid journey path"
+      val inputPath = journeyPath ?: resolved.configuredJourneysPath?.path ?: ""
+      val runArtifacts = artifactWriter.createRun(
+        suiteSlugSource = journeyPath ?: resolved.configuredJourneysPath?.path ?: "run",
+      )
+      writeParserFailureSummary(runArtifacts, inputPath, message)
+      throw CliktError(message, statusCode = EXIT_INPUT)
     }
-    val artifactWriter = RunArtifactWriter(resolved.outputPath, clock)
     val runArtifacts = artifactWriter.createRun(suiteSlugSource = path.nameWithoutExtension.ifEmpty { path.name })
     val journeys = try {
       resolveJourneys(
@@ -164,18 +169,7 @@ class RunCommand(
       throw e
     } catch (e: Exception) {
       val message = e.message ?: "Failed to resolve journeys"
-      runArtifacts.writeSummary(
-        SuiteArtifactSummary(
-          formatVersion = 1,
-          timestamp = Instant.now(clock).toString(),
-          inputPath = path.path,
-          status = ArtifactStatus.FAILED,
-          total = 0,
-          passed = 0,
-          failed = 0,
-          error = ArtifactError(ArtifactErrorKind.PARSER_FAILURE, message),
-        ),
-      )
+      writeParserFailureSummary(runArtifacts, path.path, message)
       throw CliktError(message, statusCode = EXIT_INPUT)
     }
 
@@ -303,6 +297,25 @@ class RunCommand(
     return DryRunNavigator { actions, appId, targetPlatform, context ->
       navigatorAgent.generate(actions, appId, targetPlatform, context)
     }
+  }
+
+  private suspend fun writeParserFailureSummary(
+    runArtifacts: RunArtifactDirectory,
+    inputPath: String,
+    message: String,
+  ) {
+    runArtifacts.writeSummary(
+      SuiteArtifactSummary(
+        formatVersion = 1,
+        timestamp = Instant.now(clock).toString(),
+        inputPath = inputPath,
+        status = ArtifactStatus.FAILED,
+        total = 0,
+        passed = 0,
+        failed = 0,
+        error = ArtifactError(ArtifactErrorKind.PARSER_FAILURE, message),
+      ),
+    )
   }
 
   private suspend fun writeSuiteArtifacts(

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import me.chrisbanes.verity.agent.InspectorAgent
+import me.chrisbanes.verity.agent.JourneyArtifactRecorder
 import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.NavigatorAgent
 import me.chrisbanes.verity.agent.Orchestrator
@@ -151,7 +152,7 @@ class RunCommand(
       resolveRunJourneyFile(journeyPath, resolved.configuredJourneysPath)
     } catch (e: IllegalArgumentException) {
       val message = e.message ?: "Invalid journey path"
-      val inputPath = journeyPath ?: resolved.configuredJourneysPath?.path ?: ""
+      val inputPath = journeyPath ?: resolved.configuredJourneysPath?.path ?: "<unresolved>"
       val runArtifacts = artifactWriter.createRun(
         suiteSlugSource = journeyPath ?: resolved.configuredJourneysPath?.path ?: "run",
       )
@@ -499,24 +500,32 @@ class RunCommand(
     }
 
     session.use {
-      return SuiteRunResult(
-        journeys.mapIndexed { index, resolved ->
-          val orchestrator = Orchestrator(
-            session = session,
-            navigatorFactory = navigatorFactory,
-            inspectorFactory = inspectorFactory,
-            context = projectContext.text,
-            artifactRecorder = runArtifacts.journey(index + 1, resolved.journey.name),
-          )
-          ResolvedJourneyResult(
-            resolvedJourney = resolved,
-            result = orchestrator.run(resolved.journey),
-          )
-        },
-      )
+      return runResolvedJourneysWithArtifacts(journeys, runArtifacts) { resolved, artifactRecorder ->
+        val orchestrator = Orchestrator(
+          session = session,
+          navigatorFactory = navigatorFactory,
+          inspectorFactory = inspectorFactory,
+          context = projectContext.text,
+          artifactRecorder = artifactRecorder,
+        )
+        orchestrator.run(resolved.journey)
+      }
     }
   }
 }
+
+internal suspend fun runResolvedJourneysWithArtifacts(
+  journeys: List<ResolvedJourney>,
+  runArtifacts: RunArtifactDirectory,
+  runner: suspend (ResolvedJourney, JourneyArtifactRecorder) -> JourneyResult,
+): SuiteRunResult = SuiteRunResult(
+  journeys.mapIndexed { index, resolved ->
+    ResolvedJourneyResult(
+      resolvedJourney = resolved,
+      result = runner(resolved, runArtifacts.journey(index + 1, resolved.journey.name)),
+    )
+  },
+)
 
 private fun ContextBundle.describeForCli(contextDir: File?, required: Boolean): List<String> {
   val mode = if (required) "required" else "optional"

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -69,6 +69,9 @@ class RunCommand(
   private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
   private val dryRunSuiteRunner: (suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport)? = null,
   private val clock: Clock = Clock.systemUTC(),
+  private val createRunArtifacts: suspend (File, Clock, String) -> RunArtifactDirectory = { outputRoot, runClock, suiteSlugSource ->
+    RunArtifactWriter(outputRoot, runClock).createRun(suiteSlugSource)
+  },
 ) : CliktCommand(name = "run") {
   override fun help(context: Context): String = "Execute a journey file against a connected device"
 
@@ -146,19 +149,16 @@ class RunCommand(
     }
     validateOutputDirectory(resolved.outputPath)
 
-    val artifactWriter = RunArtifactWriter(resolved.outputPath, clock)
     val path = try {
       resolveRunJourneyFile(journeyPath, resolved.configuredJourneysPath)
     } catch (e: IllegalArgumentException) {
       val message = e.message ?: "Invalid journey path"
       val inputPath = journeyPath ?: resolved.configuredJourneysPath?.path ?: "<unresolved>"
-      val runArtifacts = artifactWriter.createRun(
-        suiteSlugSource = journeyPath ?: resolved.configuredJourneysPath?.path ?: "run",
-      )
+      val runArtifacts = createRunArtifactsOrExit(resolved.outputPath, journeyPath ?: resolved.configuredJourneysPath?.path ?: "run")
       writeParserFailureSummary(runArtifacts, inputPath, message)
       throw CliktError(message, statusCode = EXIT_INPUT)
     }
-    val runArtifacts = artifactWriter.createRun(suiteSlugSource = path.nameWithoutExtension.ifEmpty { path.name })
+    val runArtifacts = createRunArtifactsOrExit(resolved.outputPath, path.nameWithoutExtension.ifEmpty { path.name })
     val journeys = try {
       resolveJourneys(
         path = path,
@@ -187,8 +187,16 @@ class RunCommand(
     }
 
     val suiteResult = try {
-      suiteRunner?.invoke(journeys)
-        ?: runSuiteWithDevice(
+      if (suiteRunner != null) {
+        try {
+          suiteRunner.invoke(journeys)
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Exception) {
+          throw JourneyExecutionFailure(e.message ?: "Journey suite failed", e)
+        }
+      } else {
+        runSuiteWithDevice(
           parent = parent,
           config = config,
           resolved = resolved,
@@ -196,8 +204,13 @@ class RunCommand(
           journeys = journeys,
           runArtifacts = runArtifacts,
         )
+      }
     } catch (e: CancellationException) {
       throw e
+    } catch (e: JourneyExecutionFailure) {
+      val message = e.message ?: "Journey suite failed"
+      writeJourneyFailureSummary(runArtifacts, path.path, message, journeys)
+      throw CliktError(message, statusCode = EXIT_JOURNEY)
     } catch (e: Exception) {
       val message = e.message ?: "Journey suite setup failed"
       writeSetupFailureSummary(runArtifacts, path.path, message)
@@ -315,6 +328,17 @@ class RunCommand(
     }
   }
 
+  private suspend fun createRunArtifactsOrExit(
+    outputPath: File,
+    suiteSlugSource: String,
+  ): RunArtifactDirectory = try {
+    createRunArtifacts(outputPath, clock, suiteSlugSource)
+  } catch (e: CancellationException) {
+    throw e
+  } catch (e: Exception) {
+    throw CliktError(e.message ?: "Failed to create run artifact directory", statusCode = EXIT_SETUP)
+  }
+
   private suspend fun writeParserFailureSummary(
     runArtifacts: RunArtifactDirectory,
     inputPath: String,
@@ -366,6 +390,41 @@ class RunCommand(
       throw e
     } catch (_: Exception) {
       // Keep setup failures controlled even when the failure is summary writing itself.
+    }
+  }
+
+  private suspend fun writeJourneyFailureSummary(
+    runArtifacts: RunArtifactDirectory,
+    inputPath: String,
+    message: String,
+    journeys: List<ResolvedJourney>,
+  ) {
+    try {
+      runArtifacts.writeSummary(
+        SuiteArtifactSummary(
+          formatVersion = 1,
+          timestamp = Instant.now(clock).toString(),
+          inputPath = inputPath,
+          status = ArtifactStatus.FAILED,
+          total = journeys.size,
+          passed = 0,
+          failed = journeys.size,
+          journeys = journeys.mapIndexed { index, item ->
+            val recorder = runArtifacts.journey(index + 1, item.journey.name)
+            SuiteJourneyArtifact(
+              path = recorder.resultPath,
+              name = item.journey.name,
+              status = ArtifactStatus.FAILED,
+            )
+          },
+          error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, message),
+          platform = journeys.firstOrNull()?.journey?.platform,
+        ),
+      )
+    } catch (e: CancellationException) {
+      throw e
+    } catch (_: Exception) {
+      // Preserve the journey failure classification even if summary writing fails.
     }
   }
 
@@ -549,19 +608,30 @@ class RunCommand(
     }
 
     session.use {
-      return runResolvedJourneysWithArtifacts(journeys, runArtifacts) { resolved, artifactRecorder ->
-        val orchestrator = Orchestrator(
-          session = session,
-          navigatorFactory = navigatorFactory,
-          inspectorFactory = inspectorFactory,
-          context = projectContext.text,
-          artifactRecorder = artifactRecorder,
-        )
-        orchestrator.run(resolved.journey)
+      return try {
+        runResolvedJourneysWithArtifacts(journeys, runArtifacts) { resolved, artifactRecorder ->
+          val orchestrator = Orchestrator(
+            session = session,
+            navigatorFactory = navigatorFactory,
+            inspectorFactory = inspectorFactory,
+            context = projectContext.text,
+            artifactRecorder = artifactRecorder,
+          )
+          orchestrator.run(resolved.journey)
+        }
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
+        throw JourneyExecutionFailure(e.message ?: "Journey suite failed", e)
       }
     }
   }
 }
+
+private class JourneyExecutionFailure(
+  message: String,
+  cause: Throwable,
+) : Exception(message, cause)
 
 internal suspend fun runResolvedJourneysWithArtifacts(
   journeys: List<ResolvedJourney>,

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -155,7 +155,11 @@ class RunCommand(
       )
     }
     val metadata = resolved.toRunArtifactMetadata()
-    validateOutputDirectory(resolved.outputPath)
+    try {
+      validateOutputDirectory(resolved.outputPath)
+    } catch (e: IllegalArgumentException) {
+      throw CliktError(e.message ?: "Invalid output path", statusCode = EXIT_SETUP)
+    }
 
     val path = try {
       resolveRunJourneyFile(journeyPath, resolved.configuredJourneysPath)
@@ -201,7 +205,7 @@ class RunCommand(
         } catch (e: CancellationException) {
           throw e
         } catch (e: Exception) {
-          throw JourneyExecutionFailure(e.message ?: "Journey suite failed", e)
+          throw JourneyExecutionFailure(e.message ?: "Journey suite failed", e, journeys.singleOrNull())
         }
       } else {
         runSuiteWithDevice(
@@ -217,7 +221,15 @@ class RunCommand(
       throw e
     } catch (e: JourneyExecutionFailure) {
       val message = e.message ?: "Journey suite failed"
-      writeJourneyFailureSummary(runArtifacts, path.path, message, journeys, metadata)
+      writeJourneyFailureSummary(
+        runArtifacts = runArtifacts,
+        inputPath = path.path,
+        message = message,
+        journeys = journeys,
+        metadata = metadata,
+        failedJourney = e.resolvedJourney ?: journeys.singleOrNull(),
+        failedAt = e.failedAt,
+      )
       throw CliktError(message, statusCode = EXIT_JOURNEY)
     } catch (e: Exception) {
       val message = e.message ?: "Journey suite setup failed"
@@ -416,8 +428,25 @@ class RunCommand(
     message: String,
     journeys: List<ResolvedJourney>,
     metadata: RunArtifactMetadata? = null,
+    failedJourney: ResolvedJourney? = null,
+    failedAt: Int? = null,
   ) {
     try {
+      val journeyRefs = failedJourney?.let { item ->
+        val index = journeys.indexOf(item).takeIf { it >= 0 }?.plus(1) ?: 1
+        val recorder = runArtifacts.journey(index, item.journey.name)
+        runArtifacts.writeJourneyResult(
+          recorder.resultPath,
+          item.toFailureArtifactResult(message, failedAt),
+        )
+        listOf(
+          SuiteJourneyArtifact(
+            path = recorder.resultPath,
+            name = item.journey.name,
+            status = ArtifactStatus.FAILED,
+          ),
+        )
+      } ?: emptyList()
       runArtifacts.writeSummary(
         SuiteArtifactSummary(
           formatVersion = 1,
@@ -427,14 +456,7 @@ class RunCommand(
           total = journeys.size,
           passed = 0,
           failed = journeys.size,
-          journeys = journeys.mapIndexed { index, item ->
-            val recorder = runArtifacts.journey(index + 1, item.journey.name)
-            SuiteJourneyArtifact(
-              path = recorder.resultPath,
-              name = item.journey.name,
-              status = ArtifactStatus.FAILED,
-            )
-          },
+          journeys = journeyRefs,
           error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, message),
           platform = journeys.firstOrNull()?.journey?.platform,
           provider = metadata?.provider,
@@ -514,6 +536,21 @@ class RunCommand(
         error = segment.error,
       )
     },
+  )
+
+  private fun ResolvedJourney.toFailureArtifactResult(
+    message: String,
+    failedAt: Int?,
+  ): JourneyArtifactResult = JourneyArtifactResult(
+    journey = JourneyArtifactIdentity(
+      name = journey.name,
+      file = file.path,
+      app = journey.app,
+      platform = journey.platform,
+    ),
+    passed = false,
+    failedAt = failedAt,
+    error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, message),
   )
 
   private fun printSuiteResult(suiteResult: SuiteRunResult) {
@@ -645,6 +682,8 @@ class RunCommand(
         }.copy(metadata = resolved.toRunArtifactMetadata())
       } catch (e: CancellationException) {
         throw e
+      } catch (e: JourneyExecutionFailure) {
+        throw e
       } catch (e: Exception) {
         throw JourneyExecutionFailure(e.message ?: "Journey suite failed", e)
       }
@@ -655,6 +694,8 @@ class RunCommand(
 private class JourneyExecutionFailure(
   message: String,
   cause: Throwable,
+  val resolvedJourney: ResolvedJourney? = null,
+  val failedAt: Int? = null,
 ) : Exception(message, cause)
 
 internal suspend fun runResolvedJourneysWithArtifacts(
@@ -662,10 +703,19 @@ internal suspend fun runResolvedJourneysWithArtifacts(
   runArtifacts: RunArtifactDirectory,
   runner: suspend (ResolvedJourney, JourneyRunArtifactRecorder) -> JourneyResult,
 ): SuiteRunResult = SuiteRunResult(
-  journeys.mapIndexed { index, resolved ->
+  results = journeys.mapIndexed { index, resolved ->
+    val result = try {
+      runner(resolved, runArtifacts.journey(index + 1, resolved.journey.name))
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: JourneyExecutionFailure) {
+      throw e
+    } catch (e: Exception) {
+      throw JourneyExecutionFailure(e.message ?: "Journey suite failed", e, resolved)
+    }
     ResolvedJourneyResult(
       resolvedJourney = resolved,
-      result = runner(resolved, runArtifacts.journey(index + 1, resolved.journey.name)),
+      result = result,
     )
   },
 )

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -74,6 +74,7 @@ class RunCommand(
   private val loadJourney: (File, AssertionStrategy) -> Journey = JourneyLoader::fromFile,
   private val listJourneyFiles: (File) -> List<File> = JourneyLoader::listJourneyFiles,
   private val loadConfig: (File) -> VerityConfig = VerityConfig::loadOrDefault,
+  private val journeyRunner: (suspend (ResolvedJourney, JourneyRunArtifactRecorder) -> JourneyResult)? = null,
   private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
   private val dryRunSuiteRunner: (suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport)? = null,
   private val clock: Clock = Clock.systemUTC(),
@@ -151,7 +152,13 @@ class RunCommand(
   override fun run() = runBlocking {
     val parent = currentContext.parent?.command as Verity
 
-    val config = loadConfig(File("verity/config.yaml"))
+    val config = try {
+      loadConfig(File("verity/config.yaml"))
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      throw CliktError(e.message ?: "Failed to load project configuration", statusCode = EXIT_SETUP)
+    }
     val cliOptions = parent.projectCliOptions()
     val resolved = try {
       if (dryRun) {
@@ -210,7 +217,9 @@ class RunCommand(
     }
 
     val suiteResult = try {
-      if (suiteRunner != null) {
+      if (journeyRunner != null) {
+        runResolvedJourneysWithArtifacts(journeys, runArtifacts, journeyRunner)
+      } else if (suiteRunner != null) {
         try {
           suiteRunner.invoke(journeys)
         } catch (e: CancellationException) {
@@ -241,6 +250,7 @@ class RunCommand(
           metadata = metadata,
           failedJourney = e.resolvedJourney ?: journeys.singleOrNull(),
           failedAt = e.failedAt,
+          completedResults = e.completedResults,
         )
       } catch (artifactError: CancellationException) {
         throw artifactError
@@ -263,7 +273,7 @@ class RunCommand(
       throw e
     } catch (e: Exception) {
       val message = e.message ?: "Failed to write run artifacts"
-      writeSetupFailureSummary(runArtifacts, path.path, message, suiteResult, metadata)
+      writeSetupFailureSummary(runArtifacts, path.path, message, metadata = metadata)
       throw CliktError(message, statusCode = EXIT_SETUP)
     }
 
@@ -468,8 +478,19 @@ class RunCommand(
     metadata: RunArtifactMetadata? = null,
     failedJourney: ResolvedJourney? = null,
     failedAt: Int? = null,
+    completedResults: List<ResolvedJourneyResult> = emptyList(),
   ) {
-    val journeyRefs = failedJourney?.let { item ->
+    val completedRefs = completedResults.map { item ->
+      val index = journeys.indexOf(item.resolvedJourney).takeIf { it >= 0 }?.plus(1) ?: 1
+      val recorder = runArtifacts.journey(index, item.resolvedJourney.journey.name)
+      writeJourneyResult(runArtifacts, recorder.resultPath, item.toArtifactResult())
+      SuiteJourneyArtifact(
+        path = recorder.resultPath,
+        name = item.resolvedJourney.journey.name,
+        status = if (item.result.passed) ArtifactStatus.PASSED else ArtifactStatus.FAILED,
+      )
+    }
+    val failedRef = failedJourney?.let { item ->
       val index = journeys.indexOf(item).takeIf { it >= 0 }?.plus(1) ?: 1
       val recorder = runArtifacts.journey(index, item.journey.name)
       writeJourneyResult(
@@ -477,14 +498,13 @@ class RunCommand(
         recorder.resultPath,
         item.toFailureArtifactResult(message, failedAt),
       )
-      listOf(
-        SuiteJourneyArtifact(
-          path = recorder.resultPath,
-          name = item.journey.name,
-          status = ArtifactStatus.FAILED,
-        ),
+      SuiteJourneyArtifact(
+        path = recorder.resultPath,
+        name = item.journey.name,
+        status = ArtifactStatus.FAILED,
       )
-    } ?: emptyList()
+    }
+    val journeyRefs = completedRefs + listOfNotNull(failedRef)
     writeSummary(
       runArtifacts,
       SuiteArtifactSummary(
@@ -492,9 +512,9 @@ class RunCommand(
         timestamp = Instant.now(clock).toString(),
         inputPath = inputPath,
         status = ArtifactStatus.FAILED,
-        total = journeys.size,
-        passed = 0,
-        failed = journeys.size,
+        total = journeyRefs.size,
+        passed = journeyRefs.count { it.status == ArtifactStatus.PASSED },
+        failed = journeyRefs.count { it.status == ArtifactStatus.FAILED },
         journeys = journeyRefs,
         error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, message),
         platform = journeys.firstOrNull()?.journey?.platform,
@@ -731,14 +751,16 @@ private class JourneyExecutionFailure(
   cause: Throwable,
   val resolvedJourney: ResolvedJourney? = null,
   val failedAt: Int? = null,
+  val completedResults: List<ResolvedJourneyResult> = emptyList(),
 ) : Exception(message, cause)
 
 internal suspend fun runResolvedJourneysWithArtifacts(
   journeys: List<ResolvedJourney>,
   runArtifacts: RunArtifactDirectory,
   runner: suspend (ResolvedJourney, JourneyRunArtifactRecorder) -> JourneyResult,
-): SuiteRunResult = SuiteRunResult(
-  results = journeys.mapIndexed { index, resolved ->
+): SuiteRunResult {
+  val results = mutableListOf<ResolvedJourneyResult>()
+  journeys.forEachIndexed { index, resolved ->
     val result = try {
       runner(resolved, runArtifacts.journey(index + 1, resolved.journey.name))
     } catch (e: CancellationException) {
@@ -746,14 +768,15 @@ internal suspend fun runResolvedJourneysWithArtifacts(
     } catch (e: JourneyExecutionFailure) {
       throw e
     } catch (e: Exception) {
-      throw JourneyExecutionFailure(e.message ?: "Journey suite failed", e, resolved)
+      throw JourneyExecutionFailure(e.message ?: "Journey suite failed", e, resolved, completedResults = results.toList())
     }
-    ResolvedJourneyResult(
+    results += ResolvedJourneyResult(
       resolvedJourney = resolved,
       result = result,
     )
-  },
-)
+  }
+  return SuiteRunResult(results = results)
+}
 
 private fun ContextBundle.describeForCli(contextDir: File?, required: Boolean): List<String> {
   val mode = if (required) "required" else "optional"

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -80,6 +80,12 @@ class RunCommand(
   private val createRunArtifacts: suspend (File, Clock, String) -> RunArtifactDirectory = { outputRoot, runClock, suiteSlugSource ->
     RunArtifactWriter(outputRoot, runClock).createRun(suiteSlugSource)
   },
+  private val writeSummary: suspend (RunArtifactDirectory, SuiteArtifactSummary) -> Unit = { runArtifacts, summary ->
+    runArtifacts.writeSummary(summary)
+  },
+  private val writeJourneyResult: suspend (RunArtifactDirectory, String, JourneyArtifactResult) -> Unit = { runArtifacts, path, result ->
+    runArtifacts.writeJourneyResult(path, result)
+  },
 ) : CliktCommand(name = "run") {
   override fun help(context: Context): String = "Execute a journey file against a connected device"
 
@@ -172,7 +178,7 @@ class RunCommand(
       val message = e.message ?: "Invalid journey path"
       val inputPath = journeyPath ?: resolved.configuredJourneysPath?.path ?: "<unresolved>"
       val runArtifacts = createRunArtifactsOrExit(resolved.outputPath, journeyPath ?: resolved.configuredJourneysPath?.path ?: "run")
-      writeParserFailureSummary(runArtifacts, inputPath, message, metadata)
+      writeParserFailureSummaryOrExitSetup(runArtifacts, inputPath, message, metadata)
       throw CliktError(message, statusCode = EXIT_INPUT)
     }
     val runArtifacts = createRunArtifactsOrExit(resolved.outputPath, path.nameWithoutExtension.ifEmpty { path.name })
@@ -186,7 +192,7 @@ class RunCommand(
       throw e
     } catch (e: Exception) {
       val message = e.message ?: "Failed to resolve journeys"
-      writeParserFailureSummary(runArtifacts, path.path, message, metadata)
+      writeParserFailureSummaryOrExitSetup(runArtifacts, path.path, message, metadata)
       throw CliktError(message, statusCode = EXIT_INPUT)
     }
 
@@ -226,15 +232,23 @@ class RunCommand(
       throw e
     } catch (e: JourneyExecutionFailure) {
       val message = e.message ?: "Journey suite failed"
-      writeJourneyFailureSummary(
-        runArtifacts = runArtifacts,
-        inputPath = path.path,
-        message = message,
-        journeys = journeys,
-        metadata = metadata,
-        failedJourney = e.resolvedJourney ?: journeys.singleOrNull(),
-        failedAt = e.failedAt,
-      )
+      try {
+        writeJourneyFailureSummary(
+          runArtifacts = runArtifacts,
+          inputPath = path.path,
+          message = message,
+          journeys = journeys,
+          metadata = metadata,
+          failedJourney = e.resolvedJourney ?: journeys.singleOrNull(),
+          failedAt = e.failedAt,
+        )
+      } catch (artifactError: CancellationException) {
+        throw artifactError
+      } catch (artifactError: Exception) {
+        val artifactMessage = artifactError.message ?: "Failed to write journey failure artifacts"
+        writeSetupFailureSummary(runArtifacts, path.path, artifactMessage, metadata = metadata)
+        throw CliktError(artifactMessage, statusCode = EXIT_SETUP)
+      }
       throw CliktError(message, statusCode = EXIT_JOURNEY)
     } catch (e: Exception) {
       val message = e.message ?: "Journey suite setup failed"
@@ -364,13 +378,29 @@ class RunCommand(
     throw CliktError(e.message ?: "Failed to create run artifact directory", statusCode = EXIT_SETUP)
   }
 
+  private suspend fun writeParserFailureSummaryOrExitSetup(
+    runArtifacts: RunArtifactDirectory,
+    inputPath: String,
+    message: String,
+    metadata: RunArtifactMetadata? = null,
+  ) {
+    try {
+      writeParserFailureSummary(runArtifacts, inputPath, message, metadata)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      throw CliktError(e.message ?: "Failed to write parser failure summary", statusCode = EXIT_SETUP)
+    }
+  }
+
   private suspend fun writeParserFailureSummary(
     runArtifacts: RunArtifactDirectory,
     inputPath: String,
     message: String,
     metadata: RunArtifactMetadata? = null,
   ) {
-    runArtifacts.writeSummary(
+    writeSummary(
+      runArtifacts,
       SuiteArtifactSummary(
         formatVersion = 1,
         timestamp = Instant.now(clock).toString(),
@@ -396,7 +426,8 @@ class RunCommand(
   ) {
     val summaryMetadata = suiteResult?.metadata ?: metadata
     try {
-      runArtifacts.writeSummary(
+      writeSummary(
+        runArtifacts,
         SuiteArtifactSummary(
           formatVersion = 1,
           timestamp = Instant.now(clock).toString(),
@@ -436,44 +467,40 @@ class RunCommand(
     failedJourney: ResolvedJourney? = null,
     failedAt: Int? = null,
   ) {
-    try {
-      val journeyRefs = failedJourney?.let { item ->
-        val index = journeys.indexOf(item).takeIf { it >= 0 }?.plus(1) ?: 1
-        val recorder = runArtifacts.journey(index, item.journey.name)
-        runArtifacts.writeJourneyResult(
-          recorder.resultPath,
-          item.toFailureArtifactResult(message, failedAt),
-        )
-        listOf(
-          SuiteJourneyArtifact(
-            path = recorder.resultPath,
-            name = item.journey.name,
-            status = ArtifactStatus.FAILED,
-          ),
-        )
-      } ?: emptyList()
-      runArtifacts.writeSummary(
-        SuiteArtifactSummary(
-          formatVersion = 1,
-          timestamp = Instant.now(clock).toString(),
-          inputPath = inputPath,
+    val journeyRefs = failedJourney?.let { item ->
+      val index = journeys.indexOf(item).takeIf { it >= 0 }?.plus(1) ?: 1
+      val recorder = runArtifacts.journey(index, item.journey.name)
+      writeJourneyResult(
+        runArtifacts,
+        recorder.resultPath,
+        item.toFailureArtifactResult(message, failedAt),
+      )
+      listOf(
+        SuiteJourneyArtifact(
+          path = recorder.resultPath,
+          name = item.journey.name,
           status = ArtifactStatus.FAILED,
-          total = journeys.size,
-          passed = 0,
-          failed = journeys.size,
-          journeys = journeyRefs,
-          error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, message),
-          platform = journeys.firstOrNull()?.journey?.platform,
-          provider = metadata?.provider,
-          navigatorModel = metadata?.navigatorModel,
-          inspectorModel = metadata?.inspectorModel,
         ),
       )
-    } catch (e: CancellationException) {
-      throw e
-    } catch (_: Exception) {
-      // Preserve the journey failure classification even if summary writing fails.
-    }
+    } ?: emptyList()
+    writeSummary(
+      runArtifacts,
+      SuiteArtifactSummary(
+        formatVersion = 1,
+        timestamp = Instant.now(clock).toString(),
+        inputPath = inputPath,
+        status = ArtifactStatus.FAILED,
+        total = journeys.size,
+        passed = 0,
+        failed = journeys.size,
+        journeys = journeyRefs,
+        error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, message),
+        platform = journeys.firstOrNull()?.journey?.platform,
+        provider = metadata?.provider,
+        navigatorModel = metadata?.navigatorModel,
+        inspectorModel = metadata?.inspectorModel,
+      ),
+    )
   }
 
   private suspend fun writeSuiteArtifacts(
@@ -483,14 +510,15 @@ class RunCommand(
   ) {
     val journeyRefs = suiteResult.results.mapIndexed { index, item ->
       val recorder = runArtifacts.journey(index + 1, item.resolvedJourney.journey.name)
-      runArtifacts.writeJourneyResult(recorder.resultPath, item.toArtifactResult())
+      writeJourneyResult(runArtifacts, recorder.resultPath, item.toArtifactResult())
       SuiteJourneyArtifact(
         path = recorder.resultPath,
         name = item.resolvedJourney.journey.name,
         status = if (item.result.passed) ArtifactStatus.PASSED else ArtifactStatus.FAILED,
       )
     }
-    runArtifacts.writeSummary(
+    writeSummary(
+      runArtifacts,
       SuiteArtifactSummary(
         formatVersion = 1,
         timestamp = Instant.now(clock).toString(),

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -12,6 +12,9 @@ import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import java.io.File
+import java.time.Clock
+import java.time.Instant
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -28,7 +31,20 @@ import me.chrisbanes.verity.core.journey.JourneyLoader
 import me.chrisbanes.verity.core.model.AssertionStrategy
 import me.chrisbanes.verity.core.model.Journey
 import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.core.result.ArtifactError
+import me.chrisbanes.verity.core.result.ArtifactErrorKind
+import me.chrisbanes.verity.core.result.ArtifactStatus
+import me.chrisbanes.verity.core.result.AssertionArtifact
+import me.chrisbanes.verity.core.result.JourneyArtifactIdentity
+import me.chrisbanes.verity.core.result.JourneyArtifactResult
+import me.chrisbanes.verity.core.result.SegmentArtifactResult
+import me.chrisbanes.verity.core.result.SuiteArtifactSummary
+import me.chrisbanes.verity.core.result.SuiteJourneyArtifact
 import me.chrisbanes.verity.device.DeviceSessionFactory
+
+private const val EXIT_INPUT = 2
+private const val EXIT_SETUP = 3
+private const val EXIT_JOURNEY = 4
 
 data class ResolvedJourney(
   val file: File,
@@ -53,6 +69,7 @@ class RunCommand(
   private val listJourneyFiles: (File) -> List<File> = JourneyLoader::listJourneyFiles,
   private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
   private val dryRunSuiteRunner: (suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport)? = null,
+  private val clock: Clock = Clock.systemUTC(),
 ) : CliktCommand(name = "run") {
   override fun help(context: Context): String = "Execute a journey file against a connected device"
 
@@ -135,11 +152,32 @@ class RunCommand(
     } catch (e: IllegalArgumentException) {
       throw UsageError(e.message ?: "Invalid journey path")
     }
-    val journeys = resolveJourneys(
-      path = path,
-      assertionStrategy = resolved.assertionStrategy,
-      platformOverride = resolved.platform,
-    )
+    val artifactWriter = RunArtifactWriter(resolved.outputPath, clock)
+    val runArtifacts = artifactWriter.createRun(suiteSlugSource = path.nameWithoutExtension.ifEmpty { path.name })
+    val journeys = try {
+      resolveJourneys(
+        path = path,
+        assertionStrategy = resolved.assertionStrategy,
+        platformOverride = resolved.platform,
+      )
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      val message = e.message ?: "Failed to resolve journeys"
+      runArtifacts.writeSummary(
+        SuiteArtifactSummary(
+          formatVersion = 1,
+          timestamp = Instant.now(clock).toString(),
+          inputPath = path.path,
+          status = ArtifactStatus.FAILED,
+          total = 0,
+          passed = 0,
+          failed = 0,
+          error = ArtifactError(ArtifactErrorKind.PARSER_FAILURE, message),
+        ),
+      )
+      throw CliktError(message, statusCode = EXIT_INPUT)
+    }
 
     if (dryRun) {
       val dryRunReport = dryRunSuiteRunner?.invoke(journeys, resolved.outputPath)
@@ -161,12 +199,14 @@ class RunCommand(
         resolved = resolved,
         path = path,
         journeys = journeys,
+        runArtifacts = runArtifacts,
       )
 
     printSuiteResult(suiteResult)
+    writeSuiteArtifacts(path, suiteResult, runArtifacts)
 
     if (!suiteResult.passed) {
-      throw CliktError("Journey suite failed")
+      throw CliktError("Journey suite failed", statusCode = EXIT_JOURNEY)
     }
   }
 
@@ -265,6 +305,71 @@ class RunCommand(
     }
   }
 
+  private suspend fun writeSuiteArtifacts(
+    path: File,
+    suiteResult: SuiteRunResult,
+    runArtifacts: RunArtifactDirectory,
+  ) {
+    val journeyRefs = suiteResult.results.mapIndexed { index, item ->
+      val key = "${(index + 1).toString().padStart(3, '0')}-${slugArtifactName(item.resolvedJourney.journey.name, "journey")}"
+      val journeyPath = "journeys/$key.json"
+      runArtifacts.writeJourneyResult(journeyPath, item.toArtifactResult())
+      SuiteJourneyArtifact(
+        path = journeyPath,
+        name = item.resolvedJourney.journey.name,
+        status = if (item.result.passed) ArtifactStatus.PASSED else ArtifactStatus.FAILED,
+      )
+    }
+    runArtifacts.writeSummary(
+      SuiteArtifactSummary(
+        formatVersion = 1,
+        timestamp = Instant.now(clock).toString(),
+        inputPath = path.path,
+        status = if (suiteResult.passed) ArtifactStatus.PASSED else ArtifactStatus.FAILED,
+        total = suiteResult.results.size,
+        passed = suiteResult.passedCount,
+        failed = suiteResult.failedCount,
+        journeys = journeyRefs,
+        error = if (suiteResult.passed) {
+          null
+        } else {
+          ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "Journey suite failed")
+        },
+        platform = suiteResult.results.firstOrNull()?.resolvedJourney?.journey?.platform,
+      ),
+    )
+  }
+
+  private fun ResolvedJourneyResult.toArtifactResult(): JourneyArtifactResult = JourneyArtifactResult(
+    journey = JourneyArtifactIdentity(
+      name = resolvedJourney.journey.name,
+      file = resolvedJourney.file.path,
+      app = resolvedJourney.journey.app,
+      platform = resolvedJourney.journey.platform,
+    ),
+    passed = result.passed,
+    failedAt = result.failedAt,
+    segments = result.segments.map { segment ->
+      val assertionMode = segment.assertionMode
+      val assertionDescription = segment.assertionDescription
+      SegmentArtifactResult(
+        index = segment.index,
+        passed = segment.passed,
+        executionMode = segment.executionMode,
+        actions = segment.actions,
+        assertion = if (assertionMode != null && assertionDescription != null) {
+          AssertionArtifact(description = assertionDescription, mode = assertionMode)
+        } else {
+          null
+        },
+        reasoning = segment.reasoning,
+        generatedFlows = segment.generatedFlows,
+        evidence = segment.evidence,
+        error = segment.error,
+      )
+    },
+  )
+
   private fun printSuiteResult(suiteResult: SuiteRunResult) {
     suiteResult.results.forEachIndexed { index, journeyResult ->
       val resolved = journeyResult.resolvedJourney
@@ -299,6 +404,7 @@ class RunCommand(
     resolved: ResolvedProjectConfig,
     path: File,
     journeys: List<ResolvedJourney>,
+    runArtifacts: RunArtifactDirectory,
   ): SuiteRunResult {
     val platform = journeys.first().journey.platform
     val contextDir = resolved.contextPath
@@ -344,49 +450,51 @@ class RunCommand(
     )
 
     val executor = MultiLLMPromptExecutor(provider.createClient(apiKey))
+    val navigatorFactory = {
+      NavigatorAgent(
+        bundledContext = if (parent.noBundledContext) "" else ContextLoader.loadBundled(),
+        agentFactory = { systemPrompt ->
+          AIAgent(
+            promptExecutor = executor,
+            llmModel = navigatorModel,
+            systemPrompt = systemPrompt,
+          )
+        },
+      )
+    }
+    val inspectorFactory = {
+      InspectorAgent(
+        treeAgentFactory = {
+          AIAgent(
+            promptExecutor = executor,
+            llmModel = inspectorModel,
+            systemPrompt = InspectorAgent.SYSTEM_PROMPT,
+          )
+        },
+        evaluateVisualContent = { systemPrompt, userMessage, screenshotPath ->
+          val p = prompt("visual-eval") {
+            system(systemPrompt)
+            user {
+              text(userMessage)
+              image(kotlinx.io.files.Path(screenshotPath.toString()))
+            }
+          }
+          val response = executor.execute(p, inspectorModel)
+          response.textContent()
+        },
+      )
+    }
 
     session.use {
-      val orchestrator = Orchestrator(
-        session = session,
-        navigatorFactory = {
-          NavigatorAgent(
-            bundledContext = if (parent.noBundledContext) "" else ContextLoader.loadBundled(),
-            agentFactory = { systemPrompt ->
-              AIAgent(
-                promptExecutor = executor,
-                llmModel = navigatorModel,
-                systemPrompt = systemPrompt,
-              )
-            },
-          )
-        },
-        inspectorFactory = {
-          InspectorAgent(
-            treeAgentFactory = {
-              AIAgent(
-                promptExecutor = executor,
-                llmModel = inspectorModel,
-                systemPrompt = InspectorAgent.SYSTEM_PROMPT,
-              )
-            },
-            evaluateVisualContent = { systemPrompt, userMessage, screenshotPath ->
-              val p = prompt("visual-eval") {
-                system(systemPrompt)
-                user {
-                  text(userMessage)
-                  image(kotlinx.io.files.Path(screenshotPath.toString()))
-                }
-              }
-              val response = executor.execute(p, inspectorModel)
-              response.textContent()
-            },
-          )
-        },
-        context = projectContext.text,
-      )
-
       return SuiteRunResult(
-        journeys.map { resolved ->
+        journeys.mapIndexed { index, resolved ->
+          val orchestrator = Orchestrator(
+            session = session,
+            navigatorFactory = navigatorFactory,
+            inspectorFactory = inspectorFactory,
+            context = projectContext.text,
+            artifactRecorder = runArtifacts.journey(index + 1, resolved.journey.name),
+          )
           ResolvedJourneyResult(
             resolvedJourney = resolved,
             result = orchestrator.run(resolved.journey),

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import me.chrisbanes.verity.agent.InspectorAgent
-import me.chrisbanes.verity.agent.JourneyArtifactRecorder
 import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.NavigatorAgent
 import me.chrisbanes.verity.agent.Orchestrator
@@ -187,18 +186,34 @@ class RunCommand(
       return@runBlocking
     }
 
-    val suiteResult = suiteRunner?.invoke(journeys)
-      ?: runSuiteWithDevice(
-        parent = parent,
-        config = config,
-        resolved = resolved,
-        path = path,
-        journeys = journeys,
-        runArtifacts = runArtifacts,
-      )
+    val suiteResult = try {
+      suiteRunner?.invoke(journeys)
+        ?: runSuiteWithDevice(
+          parent = parent,
+          config = config,
+          resolved = resolved,
+          path = path,
+          journeys = journeys,
+          runArtifacts = runArtifacts,
+        )
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      val message = e.message ?: "Journey suite setup failed"
+      writeSetupFailureSummary(runArtifacts, path.path, message)
+      throw CliktError(message, statusCode = EXIT_SETUP)
+    }
 
     printSuiteResult(suiteResult)
-    writeSuiteArtifacts(path, suiteResult, runArtifacts)
+    try {
+      writeSuiteArtifacts(path, suiteResult, runArtifacts)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      val message = e.message ?: "Failed to write run artifacts"
+      writeSetupFailureSummary(runArtifacts, path.path, message, suiteResult)
+      throw CliktError(message, statusCode = EXIT_SETUP)
+    }
 
     if (!suiteResult.passed) {
       throw CliktError("Journey suite failed", statusCode = EXIT_JOURNEY)
@@ -319,17 +334,51 @@ class RunCommand(
     )
   }
 
+  private suspend fun writeSetupFailureSummary(
+    runArtifacts: RunArtifactDirectory,
+    inputPath: String,
+    message: String,
+    suiteResult: SuiteRunResult? = null,
+  ) {
+    try {
+      runArtifacts.writeSummary(
+        SuiteArtifactSummary(
+          formatVersion = 1,
+          timestamp = Instant.now(clock).toString(),
+          inputPath = inputPath,
+          status = ArtifactStatus.FAILED,
+          total = suiteResult?.results?.size ?: 0,
+          passed = suiteResult?.passedCount ?: 0,
+          failed = suiteResult?.failedCount ?: 0,
+          journeys = suiteResult?.results?.mapIndexed { index, item ->
+            val recorder = runArtifacts.journey(index + 1, item.resolvedJourney.journey.name)
+            SuiteJourneyArtifact(
+              path = recorder.resultPath,
+              name = item.resolvedJourney.journey.name,
+              status = if (item.result.passed) ArtifactStatus.PASSED else ArtifactStatus.FAILED,
+            )
+          } ?: emptyList(),
+          error = ArtifactError(ArtifactErrorKind.SETUP_FAILURE, message),
+          platform = suiteResult?.results?.firstOrNull()?.resolvedJourney?.journey?.platform,
+        ),
+      )
+    } catch (e: CancellationException) {
+      throw e
+    } catch (_: Exception) {
+      // Keep setup failures controlled even when the failure is summary writing itself.
+    }
+  }
+
   private suspend fun writeSuiteArtifacts(
     path: File,
     suiteResult: SuiteRunResult,
     runArtifacts: RunArtifactDirectory,
   ) {
     val journeyRefs = suiteResult.results.mapIndexed { index, item ->
-      val key = "${(index + 1).toString().padStart(3, '0')}-${slugArtifactName(item.resolvedJourney.journey.name, "journey")}"
-      val journeyPath = "journeys/$key.json"
-      runArtifacts.writeJourneyResult(journeyPath, item.toArtifactResult())
+      val recorder = runArtifacts.journey(index + 1, item.resolvedJourney.journey.name)
+      runArtifacts.writeJourneyResult(recorder.resultPath, item.toArtifactResult())
       SuiteJourneyArtifact(
-        path = journeyPath,
+        path = recorder.resultPath,
         name = item.resolvedJourney.journey.name,
         status = if (item.result.passed) ArtifactStatus.PASSED else ArtifactStatus.FAILED,
       )
@@ -517,7 +566,7 @@ class RunCommand(
 internal suspend fun runResolvedJourneysWithArtifacts(
   journeys: List<ResolvedJourney>,
   runArtifacts: RunArtifactDirectory,
-  runner: suspend (ResolvedJourney, JourneyArtifactRecorder) -> JourneyResult,
+  runner: suspend (ResolvedJourney, JourneyRunArtifactRecorder) -> JourneyResult,
 ): SuiteRunResult = SuiteRunResult(
   journeys.mapIndexed { index, resolved ->
     ResolvedJourneyResult(

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/ConfigResolverTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/ConfigResolverTest.kt
@@ -125,6 +125,25 @@ class ConfigResolverTest {
   }
 
   @Test
+  fun `resolved config creates run artifact metadata`() {
+    val resolved = ResolvedProjectConfig.resolve(
+      config = VerityConfig(provider = "anthropic"),
+      cli = ProjectCliOptions(
+        navigatorModel = "claude-haiku-4-5",
+        inspectorModel = "claude-sonnet-4-5",
+      ),
+    )
+
+    assertThat(resolved.toRunArtifactMetadata()).isEqualTo(
+      RunArtifactMetadata(
+        provider = "anthropic",
+        navigatorModel = "claude-haiku-4-5",
+        inspectorModel = "claude-sonnet-4-5",
+      ),
+    )
+  }
+
+  @Test
   fun `resolved config preserves current defaults when config and cli are empty`() {
     val resolved = ResolvedProjectConfig.resolve(
       config = VerityConfig(),

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandSmokeTest.kt
@@ -38,7 +38,7 @@ class RunCommandSmokeTest {
         ),
       )
 
-    assertThat(result.statusCode).isEqualTo(1)
+    assertThat(result.statusCode).isEqualTo(3)
     assertThat(result.output)
       .contains("Required project context directory does not exist or is not a directory: /nonexistent/context")
   }

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -485,7 +485,25 @@ class RunCommandTest {
   }
 
   @Test
-  fun `journey execution exception exits 4 and writes journey failure summary`() {
+  fun `invalid output path exits 3 without summary`() {
+    val dir = createTempDirectory("verity-run-invalid-output").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputPath = File(dir, "output-file").apply { writeText("not a directory") }
+
+      val result = Verity()
+        .subcommands(runCommand(clock = fixedClock()) { error("Suite runner should not be called") })
+        .test("--output-path ${outputPath.absolutePath} run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(3)
+      assertThat(File(dir, "output-file/runs").exists()).isFalse()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `journey execution exception exits 4 and writes journey failure artifacts`() {
     val dir = createTempDirectory("verity-run-execution-failure").toFile()
     try {
       val file = writeJourney(dir, "single.journey.yaml", "Single journey")
@@ -498,13 +516,33 @@ class RunCommandTest {
         .subcommands(command)
         .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
 
-      val summary = readSummary(File(outputDir, "runs/20260708-143512-single-journey/summary.json"))
+      val runDir = File(outputDir, "runs/20260708-143512-single-journey")
+      val journeyFile = File(runDir, "journeys/001-single-journey.json")
+      val summary = readSummary(File(runDir, "summary.json"))
       assertThat(result.statusCode).isEqualTo(4)
       assertThat(summary.status).isEqualTo(ArtifactStatus.FAILED)
       assertThat(summary.total).isEqualTo(1)
       assertThat(summary.passed).isEqualTo(0)
       assertThat(summary.failed).isEqualTo(1)
+      assertThat(summary.journeys).containsExactly(
+        SuiteJourneyArtifact(
+          path = "journeys/001-single-journey.json",
+          name = "Single journey",
+          status = ArtifactStatus.FAILED,
+        ),
+      )
       assertThat(summary.error?.kind).isEqualTo(ArtifactErrorKind.JOURNEY_FAILURE)
+
+      assertThat(journeyFile.exists()).isEqualTo(true)
+      val journey = readJourney(journeyFile)
+      assertThat(journey.journey.name).isEqualTo("Single journey")
+      assertThat(journey.journey.file).isEqualTo(file.path)
+      assertThat(journey.journey.app).isEqualTo("com.example.app")
+      assertThat(journey.journey.platform).isEqualTo(Platform.ANDROID_TV)
+      assertThat(journey.passed).isEqualTo(false)
+      assertThat(journey.failedAt).isEqualTo(null)
+      assertThat(journey.segments).containsExactly()
+      assertThat(journey.error).isEqualTo(ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "visual evaluator failed"))
     } finally {
       dir.deleteRecursively()
     }

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -10,6 +10,9 @@ import assertk.assertions.isFalse
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.testing.test
 import java.io.File
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -95,7 +98,7 @@ class RunCommandTest {
         .subcommands(runCommand { error("Suite runner should not be called") })
         .test("run ${dir.absolutePath}")
 
-      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.statusCode).isEqualTo(2)
       assertThat(result.output).contains("No journey files found in: ${dir.absolutePath}")
     } finally {
       dir.deleteRecursively()
@@ -113,7 +116,7 @@ class RunCommandTest {
         .subcommands(runCommand { error("Suite runner should not be called") })
         .test("run ${dir.absolutePath}")
 
-      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.statusCode).isEqualTo(2)
       assertThat(result.output).contains("Directory suites must use a single platform")
       assertThat(result.output).contains("android.journey.yaml: ANDROID_TV")
       assertThat(result.output).contains("ios.journey.yaml: IOS")
@@ -148,7 +151,7 @@ class RunCommandTest {
         .subcommands(command)
         .test("run ${file.absolutePath}")
 
-      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.statusCode).isEqualTo(4)
       assertThat(result.output).contains("File: ${file.absolutePath}")
       assertThat(result.output).contains("Journey: Failure journey")
       assertThat(result.output).contains("FAILED: Segment 1 failed")
@@ -186,7 +189,7 @@ class RunCommandTest {
         .subcommands(command)
         .test("run ${dir.absolutePath}")
 
-      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.statusCode).isEqualTo(4)
       assertThat(seen).containsExactly("fail.journey.yaml", "pass.journey.yaml")
       assertThat(result.output).contains("Total: 2")
       assertThat(result.output).contains("Passed: 1")
@@ -232,6 +235,90 @@ class RunCommandTest {
       assertThat(result.output).contains("# Dry Run: Dry journey")
       assertThat(result.output).contains("Artifact: ${File(output, "dry-run/dry.md").path}")
       assertThat(result.output).doesNotContain("Suite result:")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `successful run writes journey result and suite summary`() {
+    val dir = createTempDirectory("verity-run-success-artifacts").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(clock = fixedClock()) { journeys ->
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true))),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
+
+      val runDir = File(outputDir, "runs/20260708-143512-single-journey")
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(File(runDir, "summary.json").exists()).isEqualTo(true)
+      assertThat(File(runDir, "journeys/001-single-journey.json").exists()).isEqualTo(true)
+      assertThat(File(runDir, "summary.json").readText()).contains("\"status\": \"passed\"")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `journey failure exits 4 and writes failed summary`() {
+    val dir = createTempDirectory("verity-run-failure-artifacts").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(clock = fixedClock()) { journeys ->
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(
+                journeyName = resolved.journey.name,
+                segments = listOf(SegmentResult(index = 0, passed = false, reasoning = "Nope")),
+              ),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
+
+      val summary = File(outputDir, "runs/20260708-143512-single-journey/summary.json")
+      assertThat(result.statusCode).isEqualTo(4)
+      assertThat(summary.exists()).isEqualTo(true)
+      assertThat(summary.readText()).contains("\"status\": \"failed\"")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `parser input failure exits 2 and writes summary`() {
+    val dir = createTempDirectory("verity-run-parser-artifacts").toFile()
+    try {
+      val missing = File(dir, "missing.journey.yaml")
+      val outputDir = File(dir, "output")
+
+      val result = Verity()
+        .subcommands(runCommand(clock = fixedClock()) { error("Suite runner should not be called") })
+        .test("--output-path ${outputDir.absolutePath} run ${missing.absolutePath}")
+
+      val summary = File(outputDir, "runs/20260708-143512-missing-journey/summary.json")
+      assertThat(result.statusCode).isEqualTo(2)
+      assertThat(summary.exists()).isEqualTo(true)
+      assertThat(summary.readText()).contains("\"kind\": \"parser_failure\"")
     } finally {
       dir.deleteRecursively()
     }
@@ -522,8 +609,11 @@ class RunCommandTest {
   }
 
   private fun runCommand(
+    clock: Clock = Clock.systemUTC(),
     runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
-  ): RunCommand = RunCommand(suiteRunner = runner)
+  ): RunCommand = RunCommand(suiteRunner = runner, clock = clock)
+
+  private fun fixedClock(): Clock = Clock.fixed(Instant.parse("2026-07-08T14:35:12Z"), ZoneOffset.UTC)
 
   private fun dryRunCommand(
     runner: suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport,

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -16,13 +16,24 @@ import java.time.ZoneOffset
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlinx.serialization.json.Json
 import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.SegmentResult
+import me.chrisbanes.verity.core.model.AssertMode
 import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.core.result.ArtifactError
+import me.chrisbanes.verity.core.result.ArtifactErrorKind
+import me.chrisbanes.verity.core.result.ArtifactStatus
+import me.chrisbanes.verity.core.result.EvidenceArtifact
+import me.chrisbanes.verity.core.result.EvidenceType
 import me.chrisbanes.verity.core.result.JourneyArtifactIdentity
 import me.chrisbanes.verity.core.result.JourneyArtifactResult
+import me.chrisbanes.verity.core.result.SegmentExecutionMode
+import me.chrisbanes.verity.core.result.SuiteArtifactSummary
+import me.chrisbanes.verity.core.result.SuiteJourneyArtifact
 
 class RunCommandTest {
+  private val json = Json { ignoreUnknownKeys = true }
 
   @Test
   fun `single-file input runs one journey`() {
@@ -251,7 +262,23 @@ class RunCommandTest {
           journeys.map { resolved ->
             ResolvedJourneyResult(
               resolvedJourney = resolved,
-              result = JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true))),
+              result = JourneyResult(
+                resolved.journey.name,
+                listOf(
+                  SegmentResult(
+                    index = 0,
+                    passed = true,
+                    assertionMode = AssertMode.VISIBLE,
+                    assertionDescription = "Home is visible",
+                    reasoning = "The Home label is visible",
+                    executionMode = SegmentExecutionMode.SLOW,
+                    actions = listOf("Open navigation", "Select Home"),
+                    generatedFlows = listOf("flows/001-single-journey/segment-000-actions.yaml"),
+                    evidence = listOf(EvidenceArtifact(EvidenceType.HIERARCHY, "evidence/001-single-journey/segment-000-tree.txt")),
+                    error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "diagnostic only"),
+                  ),
+                ),
+              ),
             )
           },
         )
@@ -262,10 +289,50 @@ class RunCommandTest {
         .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
 
       val runDir = File(outputDir, "runs/20260708-143512-single-journey")
+      val summaryFile = File(runDir, "summary.json")
+      val journeyFile = File(runDir, "journeys/001-single-journey.json")
       assertThat(result.statusCode).isEqualTo(0)
-      assertThat(File(runDir, "summary.json").exists()).isEqualTo(true)
-      assertThat(File(runDir, "journeys/001-single-journey.json").exists()).isEqualTo(true)
-      assertThat(File(runDir, "summary.json").readText()).contains("\"status\": \"passed\"")
+      assertThat(summaryFile.exists()).isEqualTo(true)
+      assertThat(journeyFile.exists()).isEqualTo(true)
+
+      val summary = readSummary(summaryFile)
+      assertThat(summary.timestamp).isEqualTo("2026-07-08T14:35:12Z")
+      assertThat(summary.inputPath).isEqualTo(file.path)
+      assertThat(summary.status).isEqualTo(ArtifactStatus.PASSED)
+      assertThat(summary.total).isEqualTo(1)
+      assertThat(summary.passed).isEqualTo(1)
+      assertThat(summary.failed).isEqualTo(0)
+      assertThat(summary.journeys).containsExactly(
+        SuiteJourneyArtifact(
+          path = "journeys/001-single-journey.json",
+          name = "Single journey",
+          status = ArtifactStatus.PASSED,
+        ),
+      )
+      assertThat(summary.error).isEqualTo(null)
+
+      val journey = readJourney(journeyFile)
+      assertThat(journey.journey.name).isEqualTo("Single journey")
+      assertThat(journey.journey.file).isEqualTo(file.path)
+      assertThat(journey.journey.app).isEqualTo("com.example.app")
+      assertThat(journey.journey.platform).isEqualTo(Platform.ANDROID_TV)
+      assertThat(journey.passed).isEqualTo(true)
+      assertThat(journey.failedAt).isEqualTo(null)
+      assertThat(journey.segments.size).isEqualTo(1)
+
+      val segment = journey.segments.single()
+      assertThat(segment.index).isEqualTo(0)
+      assertThat(segment.passed).isEqualTo(true)
+      assertThat(segment.executionMode).isEqualTo(SegmentExecutionMode.SLOW)
+      assertThat(segment.actions).containsExactly("Open navigation", "Select Home")
+      assertThat(segment.assertion?.description).isEqualTo("Home is visible")
+      assertThat(segment.assertion?.mode).isEqualTo(AssertMode.VISIBLE)
+      assertThat(segment.reasoning).isEqualTo("The Home label is visible")
+      assertThat(segment.generatedFlows).containsExactly("flows/001-single-journey/segment-000-actions.yaml")
+      assertThat(segment.evidence).containsExactly(
+        EvidenceArtifact(EvidenceType.HIERARCHY, "evidence/001-single-journey/segment-000-tree.txt"),
+      )
+      assertThat(segment.error).isEqualTo(ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "diagnostic only"))
     } finally {
       dir.deleteRecursively()
     }
@@ -284,7 +351,20 @@ class RunCommandTest {
               resolvedJourney = resolved,
               result = JourneyResult(
                 journeyName = resolved.journey.name,
-                segments = listOf(SegmentResult(index = 0, passed = false, reasoning = "Nope")),
+                segments = listOf(
+                  SegmentResult(
+                    index = 0,
+                    passed = false,
+                    assertionMode = AssertMode.TREE,
+                    assertionDescription = "Settings exists",
+                    reasoning = "Settings was missing",
+                    executionMode = SegmentExecutionMode.ASSERTION_ONLY,
+                    actions = listOf("Open settings"),
+                    generatedFlows = listOf("flows/001-single-journey/segment-000-actions.yaml"),
+                    evidence = listOf(EvidenceArtifact(EvidenceType.SCREENSHOT, "evidence/001-single-journey/segment-000-visual.png")),
+                    error = ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "Settings was missing"),
+                  ),
+                ),
               ),
             )
           },
@@ -295,10 +375,44 @@ class RunCommandTest {
         .subcommands(command)
         .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
 
-      val summary = File(outputDir, "runs/20260708-143512-single-journey/summary.json")
+      val runDir = File(outputDir, "runs/20260708-143512-single-journey")
+      val summaryFile = File(runDir, "summary.json")
+      val journeyFile = File(runDir, "journeys/001-single-journey.json")
       assertThat(result.statusCode).isEqualTo(4)
-      assertThat(summary.exists()).isEqualTo(true)
-      assertThat(summary.readText()).contains("\"status\": \"failed\"")
+      assertThat(summaryFile.exists()).isEqualTo(true)
+      assertThat(journeyFile.exists()).isEqualTo(true)
+
+      val summary = readSummary(summaryFile)
+      assertThat(summary.status).isEqualTo(ArtifactStatus.FAILED)
+      assertThat(summary.total).isEqualTo(1)
+      assertThat(summary.passed).isEqualTo(0)
+      assertThat(summary.failed).isEqualTo(1)
+      assertThat(summary.journeys).containsExactly(
+        SuiteJourneyArtifact(
+          path = "journeys/001-single-journey.json",
+          name = "Single journey",
+          status = ArtifactStatus.FAILED,
+        ),
+      )
+      assertThat(summary.error?.kind).isEqualTo(ArtifactErrorKind.JOURNEY_FAILURE)
+
+      val journey = readJourney(journeyFile)
+      assertThat(journey.passed).isEqualTo(false)
+      assertThat(journey.failedAt).isEqualTo(0)
+      assertThat(journey.segments.size).isEqualTo(1)
+      val segment = journey.segments.single()
+      assertThat(segment.index).isEqualTo(0)
+      assertThat(segment.passed).isEqualTo(false)
+      assertThat(segment.executionMode).isEqualTo(SegmentExecutionMode.ASSERTION_ONLY)
+      assertThat(segment.actions).containsExactly("Open settings")
+      assertThat(segment.assertion?.description).isEqualTo("Settings exists")
+      assertThat(segment.assertion?.mode).isEqualTo(AssertMode.TREE)
+      assertThat(segment.reasoning).isEqualTo("Settings was missing")
+      assertThat(segment.generatedFlows).containsExactly("flows/001-single-journey/segment-000-actions.yaml")
+      assertThat(segment.evidence).containsExactly(
+        EvidenceArtifact(EvidenceType.SCREENSHOT, "evidence/001-single-journey/segment-000-visual.png"),
+      )
+      assertThat(segment.error).isEqualTo(ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "Settings was missing"))
     } finally {
       dir.deleteRecursively()
     }
@@ -318,7 +432,15 @@ class RunCommandTest {
       val summary = File(outputDir, "runs/20260708-143512-missing-journey/summary.json")
       assertThat(result.statusCode).isEqualTo(2)
       assertThat(summary.exists()).isEqualTo(true)
-      assertThat(summary.readText()).contains("\"kind\": \"parser_failure\"")
+      val summaryJson = readSummary(summary)
+      assertThat(summaryJson.timestamp).isEqualTo("2026-07-08T14:35:12Z")
+      assertThat(summaryJson.inputPath).isEqualTo(missing.path)
+      assertThat(summaryJson.status).isEqualTo(ArtifactStatus.FAILED)
+      assertThat(summaryJson.total).isEqualTo(0)
+      assertThat(summaryJson.passed).isEqualTo(0)
+      assertThat(summaryJson.failed).isEqualTo(0)
+      assertThat(summaryJson.journeys).containsExactly()
+      assertThat(summaryJson.error?.kind).isEqualTo(ArtifactErrorKind.PARSER_FAILURE)
     } finally {
       dir.deleteRecursively()
     }
@@ -337,7 +459,15 @@ class RunCommandTest {
       val summary = File(outputDir, "runs/20260708-143512-run/summary.json")
       assertThat(result.statusCode).isEqualTo(2)
       assertThat(summary.exists()).isEqualTo(true)
-      assertThat(summary.readText()).contains("\"kind\": \"parser_failure\"")
+      val summaryJson = readSummary(summary)
+      assertThat(summaryJson.timestamp).isEqualTo("2026-07-08T14:35:12Z")
+      assertThat(summaryJson.inputPath).isEqualTo("")
+      assertThat(summaryJson.status).isEqualTo(ArtifactStatus.FAILED)
+      assertThat(summaryJson.total).isEqualTo(0)
+      assertThat(summaryJson.passed).isEqualTo(0)
+      assertThat(summaryJson.failed).isEqualTo(0)
+      assertThat(summaryJson.journeys).containsExactly()
+      assertThat(summaryJson.error?.kind).isEqualTo(ArtifactErrorKind.PARSER_FAILURE)
     } finally {
       dir.deleteRecursively()
     }
@@ -637,6 +767,10 @@ class RunCommandTest {
   private fun dryRunCommand(
     runner: suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport,
   ): RunCommand = RunCommand(dryRunSuiteRunner = runner)
+
+  private fun readSummary(file: File): SuiteArtifactSummary = json.decodeFromString(SuiteArtifactSummary.serializer(), file.readText())
+
+  private fun readJourney(file: File): JourneyArtifactResult = json.decodeFromString(JourneyArtifactResult.serializer(), file.readText())
 
   private fun artifactResult(): JourneyArtifactResult = JourneyArtifactResult(
     journey = JourneyArtifactIdentity(

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -598,9 +598,16 @@ class RunCommandTest {
     try {
       val missing = File(dir, "missing.journey.yaml")
       val outputDir = File(dir, "output")
+      var summaryWrites = 0
       val command = runCommand(
         clock = fixedClock(),
-        writeSummary = { _, _ -> error("summary disk full") },
+        writeSummary = { runArtifacts, summary ->
+          summaryWrites += 1
+          if (summaryWrites == 1) {
+            error("summary disk full")
+          }
+          runArtifacts.writeSummary(summary)
+        },
       ) { error("Suite runner should not be called") }
 
       val result = Verity()
@@ -609,7 +616,11 @@ class RunCommandTest {
 
       assertThat(result.statusCode).isEqualTo(3)
       assertThat(result.output).contains("summary disk full")
-      assertThat(File(outputDir, "runs/20260708-143512-missing-journey").exists()).isEqualTo(true)
+      assertThat(summaryWrites).isEqualTo(2)
+      val summary = readSummary(File(outputDir, "runs/20260708-143512-missing-journey/summary.json"))
+      assertThat(summary.status).isEqualTo(ArtifactStatus.FAILED)
+      assertThat(summary.error?.kind).isEqualTo(ArtifactErrorKind.SETUP_FAILURE)
+      assertThat(summary.error?.message).isEqualTo("summary disk full")
     } finally {
       dir.deleteRecursively()
     }

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -6,13 +6,18 @@ import assertk.assertions.containsExactly
 import assertk.assertions.doesNotContain
 import assertk.assertions.exists
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.testing.test
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.SegmentResult
+import me.chrisbanes.verity.core.model.Platform
+import me.chrisbanes.verity.core.result.JourneyArtifactIdentity
+import me.chrisbanes.verity.core.result.JourneyArtifactResult
 
 class RunCommandTest {
 
@@ -458,6 +463,64 @@ class RunCommandTest {
     }
   }
 
+  @Test
+  fun `run artifacts reject journey result paths escaping run directory`() = kotlinx.coroutines.test.runTest {
+    val dir = createTempDirectory("verity-artifacts-escape").toFile()
+    try {
+      val run = RunArtifactWriter(
+        outputRoot = dir,
+        clock = java.time.Clock.fixed(java.time.Instant.parse("2026-07-08T14:35:12Z"), java.time.ZoneOffset.UTC),
+      ).createRun(suiteSlugSource = "My Suite")
+
+      assertFailsWith<IllegalArgumentException> {
+        run.writeJourneyResult("../escape.json", artifactResult())
+      }
+
+      assertThat(File(run.directory.parent.toFile(), "escape.json").exists()).isFalse()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `run artifacts sanitize generated flow labels`() = kotlinx.coroutines.test.runTest {
+    val dir = createTempDirectory("verity-artifacts-label").toFile()
+    try {
+      val run = RunArtifactWriter(
+        outputRoot = dir,
+        clock = java.time.Clock.fixed(java.time.Instant.parse("2026-07-08T14:35:12Z"), java.time.ZoneOffset.UTC),
+      ).createRun(suiteSlugSource = "My Suite")
+      val journey = run.journey(index = 1, name = "Login")
+
+      val flow = journey.saveGeneratedFlow(segmentIndex = 2, label = "../bad label", yaml = "flow")
+
+      assertThat(flow).isEqualTo("flows/001-login/segment-002-bad-label.yaml")
+      assertThat(File(run.directory.toFile(), flow).readText()).isEqualTo("flow")
+      assertThat(File(run.directory.toFile(), "flows/001-login/segment-002-../bad label.yaml").exists()).isFalse()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `run artifacts create collision safe run directories`() = kotlinx.coroutines.test.runTest {
+    val dir = createTempDirectory("verity-artifacts-collision").toFile()
+    try {
+      val writer = RunArtifactWriter(
+        outputRoot = dir,
+        clock = java.time.Clock.fixed(java.time.Instant.parse("2026-07-08T14:35:12Z"), java.time.ZoneOffset.UTC),
+      )
+
+      val first = writer.createRun(suiteSlugSource = "My Suite")
+      val second = writer.createRun(suiteSlugSource = "My Suite")
+
+      assertThat(first.directory.toFile().name).isEqualTo("20260708-143512-my-suite")
+      assertThat(second.directory.toFile().name).isEqualTo("20260708-143512-my-suite-2")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
   private fun runCommand(
     runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
   ): RunCommand = RunCommand(suiteRunner = runner)
@@ -465,6 +528,16 @@ class RunCommandTest {
   private fun dryRunCommand(
     runner: suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport,
   ): RunCommand = RunCommand(dryRunSuiteRunner = runner)
+
+  private fun artifactResult(): JourneyArtifactResult = JourneyArtifactResult(
+    journey = JourneyArtifactIdentity(
+      name = "Login",
+      file = "login.journey.yaml",
+      app = "com.example.app",
+      platform = Platform.ANDROID_TV,
+    ),
+    passed = true,
+  )
 
   private fun writeJourney(
     dir: File,

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -420,6 +420,41 @@ class RunCommandTest {
   }
 
   @Test
+  fun `required artifact write failure exits 3 and writes setup failure summary`() {
+    val dir = createTempDirectory("verity-run-artifact-write-failure").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(clock = fixedClock()) { journeys ->
+        val runDir = File(outputDir, "runs/20260708-143512-single-journey")
+        File(runDir, "journeys").writeText("not a directory")
+        SuiteRunResult(
+          journeys.map { resolved ->
+            ResolvedJourneyResult(
+              resolvedJourney = resolved,
+              result = JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true))),
+            )
+          },
+        )
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
+
+      val summary = readSummary(File(outputDir, "runs/20260708-143512-single-journey/summary.json"))
+      assertThat(result.statusCode).isEqualTo(3)
+      assertThat(summary.status).isEqualTo(ArtifactStatus.FAILED)
+      assertThat(summary.total).isEqualTo(1)
+      assertThat(summary.passed).isEqualTo(1)
+      assertThat(summary.failed).isEqualTo(0)
+      assertThat(summary.error?.kind).isEqualTo(ArtifactErrorKind.SETUP_FAILURE)
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `parser input failure exits 2 and writes summary`() {
     val dir = createTempDirectory("verity-run-parser-artifacts").toFile()
     try {
@@ -712,8 +747,10 @@ class RunCommandTest {
         resolvedJourney("first.journey.yaml", "First journey"),
         resolvedJourney("second.journey.yaml", "Second journey"),
       )
+      val resultPaths = mutableListOf<String>()
 
       val result = runResolvedJourneysWithArtifacts(journeys, run) { resolved, recorder ->
+        resultPaths += recorder.resultPath
         val flow = recorder.saveGeneratedFlow(segmentIndex = 1, label = "actions", yaml = "flow for ${resolved.journey.name}")
         JourneyResult(
           journeyName = resolved.journey.name,
@@ -726,6 +763,7 @@ class RunCommandTest {
         .containsExactly("flows/001-first-journey/segment-001-actions.yaml")
       assertThat(result.results[1].result.segments.single().generatedFlows)
         .containsExactly("flows/002-second-journey/segment-001-actions.yaml")
+      assertThat(resultPaths).containsExactly("journeys/001-first-journey.json", "journeys/002-second-journey.json")
       assertThat(File(run.directory.toFile(), "flows/001-first-journey/segment-001-actions.yaml").readText())
         .isEqualTo("flow for First journey")
       assertThat(File(run.directory.toFile(), "flows/002-second-journey/segment-001-actions.yaml").readText())

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -260,7 +260,7 @@ class RunCommandTest {
       val outputDir = File(dir, "output")
       val command = runCommand(clock = fixedClock()) { journeys ->
         SuiteRunResult(
-          journeys.map { resolved ->
+          results = journeys.map { resolved ->
             ResolvedJourneyResult(
               resolvedJourney = resolved,
               result = JourneyResult(
@@ -282,6 +282,11 @@ class RunCommandTest {
               ),
             )
           },
+          metadata = RunArtifactMetadata(
+            provider = "ollama",
+            navigatorModel = "qwen2.5-coder",
+            inspectorModel = "llava",
+          ),
         )
       }
 
@@ -303,6 +308,9 @@ class RunCommandTest {
       assertThat(summary.total).isEqualTo(1)
       assertThat(summary.passed).isEqualTo(1)
       assertThat(summary.failed).isEqualTo(0)
+      assertThat(summary.provider).isEqualTo("ollama")
+      assertThat(summary.navigatorModel).isEqualTo("qwen2.5-coder")
+      assertThat(summary.inspectorModel).isEqualTo("llava")
       assertThat(summary.journeys).containsExactly(
         SuiteJourneyArtifact(
           path = "journeys/001-single-journey.json",

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -453,9 +453,10 @@ class RunCommandTest {
       val summary = readSummary(File(outputDir, "runs/20260708-143512-single-journey/summary.json"))
       assertThat(result.statusCode).isEqualTo(3)
       assertThat(summary.status).isEqualTo(ArtifactStatus.FAILED)
-      assertThat(summary.total).isEqualTo(1)
-      assertThat(summary.passed).isEqualTo(1)
+      assertThat(summary.total).isEqualTo(0)
+      assertThat(summary.passed).isEqualTo(0)
       assertThat(summary.failed).isEqualTo(0)
+      assertThat(summary.journeys).containsExactly()
       assertThat(summary.error?.kind).isEqualTo(ArtifactErrorKind.SETUP_FAILURE)
     } finally {
       dir.deleteRecursively()
@@ -547,6 +548,29 @@ class RunCommandTest {
   }
 
   @Test
+  fun `config load failure exits 3 before run artifacts`() {
+    val dir = createTempDirectory("verity-run-config-load-failure").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(
+        clock = fixedClock(),
+        loadConfig = { error("config is malformed") },
+      ) { error("Suite runner should not be called") }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(3)
+      assertThat(result.output).contains("config is malformed")
+      assertThat(File(outputDir, "runs").exists()).isFalse()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `journey execution exception exits 4 and writes journey failure artifacts`() {
     val dir = createTempDirectory("verity-run-execution-failure").toFile()
     try {
@@ -587,6 +611,53 @@ class RunCommandTest {
       assertThat(journey.failedAt).isEqualTo(null)
       assertThat(journey.segments).containsExactly()
       assertThat(journey.error).isEqualTo(ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "visual evaluator failed"))
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `multi journey execution exception preserves completed artifacts`() {
+    val dir = createTempDirectory("verity-run-partial-execution-failure").toFile()
+    try {
+      writeJourney(dir, "a.journey.yaml", "First journey")
+      writeJourney(dir, "b.journey.yaml", "Second journey")
+      writeJourney(dir, "c.journey.yaml", "Third journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(
+        clock = fixedClock(),
+        journeyRunner = { resolved, _ ->
+          if (resolved.journey.name == "Second journey") {
+            throw IllegalStateException("second journey crashed")
+          }
+          JourneyResult(resolved.journey.name, listOf(SegmentResult(index = 0, passed = true)))
+        },
+      ) { error("Suite runner should not be called") }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${dir.absolutePath}")
+
+      val runDir = File(outputDir, "runs").listFiles().orEmpty().single()
+      val firstFile = File(runDir, "journeys/001-first-journey.json")
+      val secondFile = File(runDir, "journeys/002-second-journey.json")
+      val thirdFile = File(runDir, "journeys/003-third-journey.json")
+      val summary = readSummary(File(runDir, "summary.json"))
+      assertThat(result.statusCode).isEqualTo(4)
+      assertThat(firstFile.exists()).isEqualTo(true)
+      assertThat(secondFile.exists()).isEqualTo(true)
+      assertThat(thirdFile.exists()).isFalse()
+      assertThat(summary.total).isEqualTo(2)
+      assertThat(summary.passed).isEqualTo(1)
+      assertThat(summary.failed).isEqualTo(1)
+      assertThat(summary.journeys).containsExactly(
+        SuiteJourneyArtifact("journeys/001-first-journey.json", "First journey", ArtifactStatus.PASSED),
+        SuiteJourneyArtifact("journeys/002-second-journey.json", "Second journey", ArtifactStatus.FAILED),
+      )
+      assertThat(readJourney(firstFile).passed).isEqualTo(true)
+      val failedJourney = readJourney(secondFile)
+      assertThat(failedJourney.passed).isEqualTo(false)
+      assertThat(failedJourney.error).isEqualTo(ArtifactError(ArtifactErrorKind.JOURNEY_FAILURE, "second journey crashed"))
     } finally {
       dir.deleteRecursively()
     }
@@ -645,7 +716,11 @@ class RunCommandTest {
 
       assertThat(result.statusCode).isEqualTo(3)
       assertThat(result.output).contains("journey result disk full")
-      assertThat(File(outputDir, "runs/20260708-143512-single-journey").exists()).isEqualTo(true)
+      val runDir = File(outputDir, "runs/20260708-143512-single-journey")
+      val summary = readSummary(File(runDir, "summary.json"))
+      assertThat(summary.error?.kind).isEqualTo(ArtifactErrorKind.SETUP_FAILURE)
+      assertThat(summary.journeys).containsExactly()
+      assertThat(File(runDir, "journeys/001-single-journey.json").exists()).isFalse()
     } finally {
       dir.deleteRecursively()
     }
@@ -1031,6 +1106,7 @@ class RunCommandTest {
   private fun runCommand(
     clock: Clock = Clock.systemUTC(),
     config: VerityConfig = VerityConfig(),
+    loadConfig: ((File) -> VerityConfig)? = null,
     createRunArtifacts: suspend (File, Clock, String) -> RunArtifactDirectory = { outputRoot, runClock, suiteSlugSource ->
       RunArtifactWriter(outputRoot, runClock).createRun(suiteSlugSource)
     },
@@ -1040,9 +1116,11 @@ class RunCommandTest {
     writeJourneyResult: suspend (RunArtifactDirectory, String, JourneyArtifactResult) -> Unit = { runArtifacts, path, result ->
       runArtifacts.writeJourneyResult(path, result)
     },
+    journeyRunner: (suspend (ResolvedJourney, JourneyRunArtifactRecorder) -> JourneyResult)? = null,
     runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
   ): RunCommand = RunCommand(
-    loadConfig = { config },
+    loadConfig = loadConfig ?: { config },
+    journeyRunner = journeyRunner,
     suiteRunner = runner,
     clock = clock,
     createRunArtifacts = createRunArtifacts,

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -233,6 +233,32 @@ class RunCommandTest {
   }
 
   @Test
+  fun `run artifacts create stable directories and relative references`() = kotlinx.coroutines.test.runTest {
+    val dir = createTempDirectory("verity-artifacts").toFile()
+    try {
+      val writer = RunArtifactWriter(
+        outputRoot = dir,
+        clock = java.time.Clock.fixed(java.time.Instant.parse("2026-07-08T14:35:12Z"), java.time.ZoneOffset.UTC),
+      )
+      val run = writer.createRun(suiteSlugSource = "My Suite")
+      val journey = run.journey(index = 1, name = "Login")
+
+      val flow = journey.saveGeneratedFlow(segmentIndex = 2, label = "actions", yaml = "appId: com.example\n---\n- tapOn: Settings")
+      val tree = journey.saveHierarchy(segmentIndex = 2, hierarchy = "[text=Home]")
+      val screenshot = journey.screenshotPath(segmentIndex = 3)
+
+      assertThat(run.directory.toFile().name).isEqualTo("20260708-143512-my-suite")
+      assertThat(flow).isEqualTo("flows/001-login/segment-002-actions.yaml")
+      assertThat(tree).isEqualTo("evidence/001-login/segment-002-tree.txt")
+      assertThat(screenshot.relativePath).isEqualTo("evidence/001-login/segment-003-visual.png")
+      assertThat(File(run.directory.toFile(), flow).readText()).contains("tapOn: Settings")
+      assertThat(File(run.directory.toFile(), tree).readText()).isEqualTo("[text=Home]")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `dry run invalid journey fails before dry-run runner`() {
     val dir = createTempDirectory("verity-run-dry-invalid").toFile()
     try {

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -593,6 +593,54 @@ class RunCommandTest {
   }
 
   @Test
+  fun `parser failure summary write failure exits 3`() {
+    val dir = createTempDirectory("verity-run-parser-summary-write-failure").toFile()
+    try {
+      val missing = File(dir, "missing.journey.yaml")
+      val outputDir = File(dir, "output")
+      val command = runCommand(
+        clock = fixedClock(),
+        writeSummary = { _, _ -> error("summary disk full") },
+      ) { error("Suite runner should not be called") }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${missing.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(3)
+      assertThat(result.output).contains("summary disk full")
+      assertThat(File(outputDir, "runs/20260708-143512-missing-journey").exists()).isEqualTo(true)
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `journey failure artifact write failure exits 3`() {
+    val dir = createTempDirectory("verity-run-journey-failure-write-failure").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(
+        clock = fixedClock(),
+        writeJourneyResult = { _, _, _ -> error("journey result disk full") },
+      ) {
+        throw IllegalStateException("visual evaluator failed")
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(3)
+      assertThat(result.output).contains("journey result disk full")
+      assertThat(File(outputDir, "runs/20260708-143512-single-journey").exists()).isEqualTo(true)
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `parser input failure exits 2 and writes summary`() {
     val dir = createTempDirectory("verity-run-parser-artifacts").toFile()
     try {
@@ -975,12 +1023,20 @@ class RunCommandTest {
     createRunArtifacts: suspend (File, Clock, String) -> RunArtifactDirectory = { outputRoot, runClock, suiteSlugSource ->
       RunArtifactWriter(outputRoot, runClock).createRun(suiteSlugSource)
     },
+    writeSummary: suspend (RunArtifactDirectory, me.chrisbanes.verity.core.result.SuiteArtifactSummary) -> Unit = { runArtifacts, summary ->
+      runArtifacts.writeSummary(summary)
+    },
+    writeJourneyResult: suspend (RunArtifactDirectory, String, JourneyArtifactResult) -> Unit = { runArtifacts, path, result ->
+      runArtifacts.writeJourneyResult(path, result)
+    },
     runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
   ): RunCommand = RunCommand(
     loadConfig = { config },
     suiteRunner = runner,
     clock = clock,
     createRunArtifacts = createRunArtifacts,
+    writeSummary = writeSummary,
+    writeJourneyResult = writeJourneyResult,
   )
 
   private fun fixedClock(): Clock = Clock.fixed(Instant.parse("2026-07-08T14:35:12Z"), ZoneOffset.UTC)

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -818,7 +818,7 @@ class RunCommandTest {
         .subcommands(dryRunCommand { _, _ -> error("dry-run runner should not be called") })
         .test("run --dry-run ${file.absolutePath}")
 
-      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.statusCode).isEqualTo(2)
       assertThat(result.output).contains("invalid.journey.yaml")
     } finally {
       dir.deleteRecursively()
@@ -870,7 +870,7 @@ class RunCommandTest {
         .subcommands(dryRunCommand { _, _ -> error("dry-run runner should not be called") })
         .test("run --dry-run ${dir.absolutePath}")
 
-      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.statusCode).isEqualTo(2)
       assertThat(result.output).contains("Directory suites must use a single platform")
     } finally {
       dir.deleteRecursively()

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -503,6 +503,50 @@ class RunCommandTest {
   }
 
   @Test
+  fun `invalid assertion strategy exits 3 before run artifacts`() {
+    val dir = createTempDirectory("verity-run-invalid-assertion-strategy").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+
+      val result = Verity()
+        .subcommands(runCommand(clock = fixedClock()) { error("Suite runner should not be called") })
+        .test("--output-path ${outputDir.absolutePath} --assertion-strategy expensive run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(3)
+      assertThat(result.output).contains("assertions.strategy")
+      assertThat(result.output).contains("expensive")
+      assertThat(File(outputDir, "runs").exists()).isFalse()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `invalid config platform exits 3 before run artifacts`() {
+    val dir = createTempDirectory("verity-run-invalid-config-platform").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(
+        clock = fixedClock(),
+        config = VerityConfig(device = VerityDeviceConfig(platform = "watch")),
+      ) { error("Suite runner should not be called") }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(3)
+      assertThat(result.output).contains("device.platform")
+      assertThat(result.output).contains("watch")
+      assertThat(File(outputDir, "runs").exists()).isFalse()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `journey execution exception exits 4 and writes journey failure artifacts`() {
     val dir = createTempDirectory("verity-run-execution-failure").toFile()
     try {
@@ -927,11 +971,17 @@ class RunCommandTest {
 
   private fun runCommand(
     clock: Clock = Clock.systemUTC(),
+    config: VerityConfig = VerityConfig(),
     createRunArtifacts: suspend (File, Clock, String) -> RunArtifactDirectory = { outputRoot, runClock, suiteSlugSource ->
       RunArtifactWriter(outputRoot, runClock).createRun(suiteSlugSource)
     },
     runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
-  ): RunCommand = RunCommand(suiteRunner = runner, clock = clock, createRunArtifacts = createRunArtifacts)
+  ): RunCommand = RunCommand(
+    loadConfig = { config },
+    suiteRunner = runner,
+    clock = clock,
+    createRunArtifacts = createRunArtifacts,
+  )
 
   private fun fixedClock(): Clock = Clock.fixed(Instant.parse("2026-07-08T14:35:12Z"), ZoneOffset.UTC)
 

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -455,6 +455,54 @@ class RunCommandTest {
   }
 
   @Test
+  fun `run directory creation failure exits 3 without summary`() {
+    val dir = createTempDirectory("verity-run-create-failure").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(
+        clock = fixedClock(),
+        createRunArtifacts = { _, _, _ -> error("cannot create run directory") },
+      ) { error("Suite runner should not be called") }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(3)
+      assertThat(File(outputDir, "runs").exists()).isFalse()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `journey execution exception exits 4 and writes journey failure summary`() {
+    val dir = createTempDirectory("verity-run-execution-failure").toFile()
+    try {
+      val file = writeJourney(dir, "single.journey.yaml", "Single journey")
+      val outputDir = File(dir, "output")
+      val command = runCommand(clock = fixedClock()) {
+        throw IllegalStateException("visual evaluator failed")
+      }
+
+      val result = Verity()
+        .subcommands(command)
+        .test("--output-path ${outputDir.absolutePath} run ${file.absolutePath}")
+
+      val summary = readSummary(File(outputDir, "runs/20260708-143512-single-journey/summary.json"))
+      assertThat(result.statusCode).isEqualTo(4)
+      assertThat(summary.status).isEqualTo(ArtifactStatus.FAILED)
+      assertThat(summary.total).isEqualTo(1)
+      assertThat(summary.passed).isEqualTo(0)
+      assertThat(summary.failed).isEqualTo(1)
+      assertThat(summary.error?.kind).isEqualTo(ArtifactErrorKind.JOURNEY_FAILURE)
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `parser input failure exits 2 and writes summary`() {
     val dir = createTempDirectory("verity-run-parser-artifacts").toFile()
     try {
@@ -833,8 +881,11 @@ class RunCommandTest {
 
   private fun runCommand(
     clock: Clock = Clock.systemUTC(),
+    createRunArtifacts: suspend (File, Clock, String) -> RunArtifactDirectory = { outputRoot, runClock, suiteSlugSource ->
+      RunArtifactWriter(outputRoot, runClock).createRun(suiteSlugSource)
+    },
     runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
-  ): RunCommand = RunCommand(suiteRunner = runner, clock = clock)
+  ): RunCommand = RunCommand(suiteRunner = runner, clock = clock, createRunArtifacts = createRunArtifacts)
 
   private fun fixedClock(): Clock = Clock.fixed(Instant.parse("2026-07-08T14:35:12Z"), ZoneOffset.UTC)
 

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.Json
 import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.SegmentResult
 import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Journey
 import me.chrisbanes.verity.core.model.Platform
 import me.chrisbanes.verity.core.result.ArtifactError
 import me.chrisbanes.verity.core.result.ArtifactErrorKind
@@ -461,7 +462,7 @@ class RunCommandTest {
       assertThat(summary.exists()).isEqualTo(true)
       val summaryJson = readSummary(summary)
       assertThat(summaryJson.timestamp).isEqualTo("2026-07-08T14:35:12Z")
-      assertThat(summaryJson.inputPath).isEqualTo("")
+      assertThat(summaryJson.inputPath).isEqualTo("<unresolved>")
       assertThat(summaryJson.status).isEqualTo(ArtifactStatus.FAILED)
       assertThat(summaryJson.total).isEqualTo(0)
       assertThat(summaryJson.passed).isEqualTo(0)
@@ -700,6 +701,41 @@ class RunCommandTest {
   }
 
   @Test
+  fun `real suite artifact runner passes distinct journey recorders`() = kotlinx.coroutines.test.runTest {
+    val dir = createTempDirectory("verity-run-artifact-runner").toFile()
+    try {
+      val run = RunArtifactWriter(
+        outputRoot = dir,
+        clock = fixedClock(),
+      ).createRun(suiteSlugSource = "suite")
+      val journeys = listOf(
+        resolvedJourney("first.journey.yaml", "First journey"),
+        resolvedJourney("second.journey.yaml", "Second journey"),
+      )
+
+      val result = runResolvedJourneysWithArtifacts(journeys, run) { resolved, recorder ->
+        val flow = recorder.saveGeneratedFlow(segmentIndex = 1, label = "actions", yaml = "flow for ${resolved.journey.name}")
+        JourneyResult(
+          journeyName = resolved.journey.name,
+          segments = listOf(SegmentResult(index = 1, passed = true, generatedFlows = listOfNotNull(flow))),
+        )
+      }
+
+      assertThat(result.passed).isEqualTo(true)
+      assertThat(result.results[0].result.segments.single().generatedFlows)
+        .containsExactly("flows/001-first-journey/segment-001-actions.yaml")
+      assertThat(result.results[1].result.segments.single().generatedFlows)
+        .containsExactly("flows/002-second-journey/segment-001-actions.yaml")
+      assertThat(File(run.directory.toFile(), "flows/001-first-journey/segment-001-actions.yaml").readText())
+        .isEqualTo("flow for First journey")
+      assertThat(File(run.directory.toFile(), "flows/002-second-journey/segment-001-actions.yaml").readText())
+        .isEqualTo("flow for Second journey")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `run artifacts reject journey result paths escaping run directory`() = kotlinx.coroutines.test.runTest {
     val dir = createTempDirectory("verity-artifacts-escape").toFile()
     try {
@@ -771,6 +807,16 @@ class RunCommandTest {
   private fun readSummary(file: File): SuiteArtifactSummary = json.decodeFromString(SuiteArtifactSummary.serializer(), file.readText())
 
   private fun readJourney(file: File): JourneyArtifactResult = json.decodeFromString(JourneyArtifactResult.serializer(), file.readText())
+
+  private fun resolvedJourney(fileName: String, name: String): ResolvedJourney = ResolvedJourney(
+    file = File(fileName),
+    journey = Journey(
+      name = name,
+      app = "com.example.app",
+      platform = Platform.ANDROID_TV,
+      steps = emptyList(),
+    ),
+  )
 
   private fun artifactResult(): JourneyArtifactResult = JourneyArtifactResult(
     journey = JourneyArtifactIdentity(

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -325,6 +325,25 @@ class RunCommandTest {
   }
 
   @Test
+  fun `unresolved input failure exits 2 and writes summary`() {
+    val dir = createTempDirectory("verity-run-unresolved-artifacts").toFile()
+    try {
+      val outputDir = File(dir, "output")
+
+      val result = Verity()
+        .subcommands(runCommand(clock = fixedClock()) { error("Suite runner should not be called") })
+        .test("--output-path ${outputDir.absolutePath} run")
+
+      val summary = File(outputDir, "runs/20260708-143512-run/summary.json")
+      assertThat(result.statusCode).isEqualTo(2)
+      assertThat(summary.exists()).isEqualTo(true)
+      assertThat(summary.readText()).contains("\"kind\": \"parser_failure\"")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
   fun `run artifacts create stable directories and relative references`() = kotlinx.coroutines.test.runTest {
     val dir = createTempDirectory("verity-artifacts").toFile()
     try {

--- a/verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt
+++ b/verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt
@@ -76,7 +76,7 @@ data class SuiteArtifactSummary(
   val failed: Int,
   val journeys: List<SuiteJourneyArtifact> = emptyList(),
   val error: ArtifactError? = null,
-  val platform: String? = null,
+  @Serializable(with = PlatformWireSerializer::class) val platform: Platform? = null,
   val provider: String? = null,
   val navigatorModel: String? = null,
   val inspectorModel: String? = null,

--- a/verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt
+++ b/verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt
@@ -56,6 +56,7 @@ data class JourneyArtifactResult(
   val passed: Boolean,
   val failedAt: Int? = null,
   val segments: List<SegmentArtifactResult> = emptyList(),
+  val error: ArtifactError? = null,
 )
 
 @Serializable

--- a/verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt
+++ b/verity/core/src/main/kotlin/me/chrisbanes/verity/core/result/RunResultContract.kt
@@ -1,0 +1,164 @@
+package me.chrisbanes.verity.core.result
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Platform
+
+@Serializable
+data class JourneyArtifactIdentity(
+  val name: String,
+  val file: String,
+  val app: String,
+  @Serializable(with = PlatformWireSerializer::class) val platform: Platform,
+)
+
+@Serializable
+data class AssertionArtifact(
+  val description: String,
+  @Serializable(with = AssertModeWireSerializer::class) val mode: AssertMode,
+)
+
+@Serializable
+data class EvidenceArtifact(
+  val type: EvidenceType,
+  val path: String,
+)
+
+@Serializable
+data class ArtifactError(
+  val kind: ArtifactErrorKind,
+  val message: String,
+)
+
+@Serializable
+data class SegmentArtifactResult(
+  val index: Int,
+  val passed: Boolean,
+  val executionMode: SegmentExecutionMode,
+  val actions: List<String> = emptyList(),
+  val assertion: AssertionArtifact? = null,
+  val reasoning: String = "",
+  val generatedFlows: List<String> = emptyList(),
+  val evidence: List<EvidenceArtifact> = emptyList(),
+  val error: ArtifactError? = null,
+)
+
+@Serializable
+data class JourneyArtifactResult(
+  val journey: JourneyArtifactIdentity,
+  val passed: Boolean,
+  val failedAt: Int? = null,
+  val segments: List<SegmentArtifactResult> = emptyList(),
+)
+
+@Serializable
+data class SuiteJourneyArtifact(
+  val path: String,
+  val name: String,
+  val status: ArtifactStatus,
+)
+
+@Serializable
+data class SuiteArtifactSummary(
+  val formatVersion: Int,
+  val timestamp: String,
+  val inputPath: String,
+  val status: ArtifactStatus,
+  val total: Int,
+  val passed: Int,
+  val failed: Int,
+  val journeys: List<SuiteJourneyArtifact> = emptyList(),
+  val error: ArtifactError? = null,
+  val platform: String? = null,
+  val provider: String? = null,
+  val navigatorModel: String? = null,
+  val inspectorModel: String? = null,
+)
+
+@Serializable
+enum class ArtifactStatus {
+  @SerialName("passed")
+  PASSED,
+
+  @SerialName("failed")
+  FAILED,
+}
+
+@Serializable
+enum class SegmentExecutionMode {
+  @SerialName("fast")
+  FAST,
+
+  @SerialName("slow")
+  SLOW,
+
+  @SerialName("loop")
+  LOOP,
+
+  @SerialName("assertion-only")
+  ASSERTION_ONLY,
+}
+
+@Serializable
+enum class EvidenceType {
+  @SerialName("flow")
+  FLOW,
+
+  @SerialName("screenshot")
+  SCREENSHOT,
+
+  @SerialName("hierarchy")
+  HIERARCHY,
+}
+
+@Serializable
+enum class ArtifactErrorKind {
+  @SerialName("parser_failure")
+  PARSER_FAILURE,
+
+  @SerialName("setup_failure")
+  SETUP_FAILURE,
+
+  @SerialName("journey_failure")
+  JOURNEY_FAILURE,
+}
+
+object PlatformWireSerializer : KSerializer<Platform> {
+  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Platform", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: Platform) = encoder.encodeString(
+    when (value) {
+      Platform.ANDROID_TV -> "android-tv"
+      Platform.ANDROID_MOBILE -> "android"
+      Platform.IOS -> "ios"
+    },
+  )
+
+  override fun deserialize(decoder: Decoder): Platform = when (val value = decoder.decodeString()) {
+    "android-tv" -> Platform.ANDROID_TV
+    "android" -> Platform.ANDROID_MOBILE
+    "ios" -> Platform.IOS
+    else -> error("Unknown platform: $value")
+  }
+}
+
+object AssertModeWireSerializer : KSerializer<AssertMode> {
+  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("AssertMode", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: AssertMode) = encoder.encodeString(value.name.lowercase())
+
+  override fun deserialize(decoder: Decoder): AssertMode = when (val value = decoder.decodeString()) {
+    "visible" -> AssertMode.VISIBLE
+    "focused" -> AssertMode.FOCUSED
+    "tree" -> AssertMode.TREE
+    "visual" -> AssertMode.VISUAL
+    else -> error("Unknown assert mode: $value")
+  }
+}

--- a/verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt
+++ b/verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt
@@ -1,0 +1,99 @@
+package me.chrisbanes.verity.core.result
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.serialization.json.Json
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Platform
+
+class RunResultContractTest {
+  private val json = Json {
+    prettyPrint = false
+    encodeDefaults = true
+    explicitNulls = false
+  }
+
+  @Test
+  fun `journey result serializes stable lowercase values and camelCase fields`() {
+    val result = JourneyArtifactResult(
+      journey = JourneyArtifactIdentity(
+        name = "Login",
+        file = "journeys/login.journey.yaml",
+        app = "com.example.app",
+        platform = Platform.ANDROID_TV,
+      ),
+      passed = false,
+      failedAt = 2,
+      segments = listOf(
+        SegmentArtifactResult(
+          index = 2,
+          passed = false,
+          executionMode = SegmentExecutionMode.SLOW,
+          actions = listOf("Navigate to Settings"),
+          assertion = AssertionArtifact(description = "Settings is visible", mode = AssertMode.TREE),
+          reasoning = "Expected Settings but saw Home",
+          generatedFlows = listOf("flows/001-login/segment-002-actions.yaml"),
+          evidence = listOf(
+            EvidenceArtifact(type = EvidenceType.HIERARCHY, path = "evidence/001-login/segment-002-tree.txt"),
+          ),
+          error = ArtifactError(kind = ArtifactErrorKind.JOURNEY_FAILURE, message = "Expected Settings but saw Home"),
+        ),
+      ),
+    )
+
+    val encoded = json.encodeToString(JourneyArtifactResult.serializer(), result)
+
+    assertThat(encoded).contains("\"platform\":\"android-tv\"")
+    assertThat(encoded).contains("\"executionMode\":\"slow\"")
+    assertThat(encoded).contains("\"mode\":\"tree\"")
+    assertThat(encoded).contains("\"type\":\"hierarchy\"")
+    assertThat(encoded).contains("\"kind\":\"journey_failure\"")
+    assertThat(encoded).contains("\"generatedFlows\"")
+  }
+
+  @Test
+  fun `suite summary serializes status counts and journey references`() {
+    val summary = SuiteArtifactSummary(
+      formatVersion = 1,
+      timestamp = "2026-07-08T14:35:12Z",
+      inputPath = "journeys",
+      status = ArtifactStatus.FAILED,
+      total = 2,
+      passed = 1,
+      failed = 1,
+      journeys = listOf(
+        SuiteJourneyArtifact(path = "journeys/001-login.json", name = "Login", status = ArtifactStatus.PASSED),
+        SuiteJourneyArtifact(path = "journeys/002-browse.json", name = "Browse", status = ArtifactStatus.FAILED),
+      ),
+      error = ArtifactError(kind = ArtifactErrorKind.JOURNEY_FAILURE, message = "One or more journeys failed"),
+    )
+
+    val encoded = json.encodeToString(SuiteArtifactSummary.serializer(), summary)
+
+    assertThat(encoded).contains("\"formatVersion\":1")
+    assertThat(encoded).contains("\"status\":\"failed\"")
+    assertThat(encoded).contains("\"passed\":1")
+    assertThat(encoded).contains("\"failed\":1")
+    assertThat(encoded).contains("\"path\":\"journeys/001-login.json\"")
+  }
+
+  @Test
+  fun `platform and assert mode decode from stable wire values`() {
+    val decoded = json.decodeFromString(
+      JourneyArtifactResult.serializer(),
+      """
+      {
+        "journey":{"name":"Login","file":"login.journey.yaml","app":"com.example.app","platform":"android"},
+        "passed":true,
+        "segments":[{"index":0,"passed":true,"executionMode":"assertion-only","assertion":{"description":"Home","mode":"visible"}}]
+      }
+      """.trimIndent(),
+    )
+
+    assertThat(decoded.journey.platform).isEqualTo(Platform.ANDROID_MOBILE)
+    assertThat(decoded.segments.single().assertion?.mode).isEqualTo(AssertMode.VISIBLE)
+    assertThat(decoded.segments.single().executionMode).isEqualTo(SegmentExecutionMode.ASSERTION_ONLY)
+  }
+}

--- a/verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt
+++ b/verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt
@@ -96,4 +96,80 @@ class RunResultContractTest {
     assertThat(decoded.segments.single().assertion?.mode).isEqualTo(AssertMode.VISIBLE)
     assertThat(decoded.segments.single().executionMode).isEqualTo(SegmentExecutionMode.ASSERTION_ONLY)
   }
+
+  @Test
+  fun `platform encodes and decodes all stable wire values`() {
+    assertThat(json.encodeToString(PlatformWireSerializer, Platform.ANDROID_TV)).isEqualTo("\"android-tv\"")
+    assertThat(json.encodeToString(PlatformWireSerializer, Platform.ANDROID_MOBILE)).isEqualTo("\"android\"")
+    assertThat(json.encodeToString(PlatformWireSerializer, Platform.IOS)).isEqualTo("\"ios\"")
+
+    assertThat(json.decodeFromString(PlatformWireSerializer, "\"android-tv\"")).isEqualTo(Platform.ANDROID_TV)
+    assertThat(json.decodeFromString(PlatformWireSerializer, "\"android\"")).isEqualTo(Platform.ANDROID_MOBILE)
+    assertThat(json.decodeFromString(PlatformWireSerializer, "\"ios\"")).isEqualTo(Platform.IOS)
+  }
+
+  @Test
+  fun `assert mode encodes and decodes all stable wire values`() {
+    assertThat(json.encodeToString(AssertModeWireSerializer, AssertMode.VISIBLE)).isEqualTo("\"visible\"")
+    assertThat(json.encodeToString(AssertModeWireSerializer, AssertMode.FOCUSED)).isEqualTo("\"focused\"")
+    assertThat(json.encodeToString(AssertModeWireSerializer, AssertMode.TREE)).isEqualTo("\"tree\"")
+    assertThat(json.encodeToString(AssertModeWireSerializer, AssertMode.VISUAL)).isEqualTo("\"visual\"")
+
+    assertThat(json.decodeFromString(AssertModeWireSerializer, "\"visible\"")).isEqualTo(AssertMode.VISIBLE)
+    assertThat(json.decodeFromString(AssertModeWireSerializer, "\"focused\"")).isEqualTo(AssertMode.FOCUSED)
+    assertThat(json.decodeFromString(AssertModeWireSerializer, "\"tree\"")).isEqualTo(AssertMode.TREE)
+    assertThat(json.decodeFromString(AssertModeWireSerializer, "\"visual\"")).isEqualTo(AssertMode.VISUAL)
+  }
+
+  @Test
+  fun `artifact status encodes and decodes all stable wire values`() {
+    assertThat(json.encodeToString(ArtifactStatus.serializer(), ArtifactStatus.PASSED)).isEqualTo("\"passed\"")
+    assertThat(json.encodeToString(ArtifactStatus.serializer(), ArtifactStatus.FAILED)).isEqualTo("\"failed\"")
+
+    assertThat(json.decodeFromString(ArtifactStatus.serializer(), "\"passed\"")).isEqualTo(ArtifactStatus.PASSED)
+    assertThat(json.decodeFromString(ArtifactStatus.serializer(), "\"failed\"")).isEqualTo(ArtifactStatus.FAILED)
+  }
+
+  @Test
+  fun `segment execution mode encodes and decodes all stable wire values`() {
+    assertThat(json.encodeToString(SegmentExecutionMode.serializer(), SegmentExecutionMode.FAST)).isEqualTo("\"fast\"")
+    assertThat(json.encodeToString(SegmentExecutionMode.serializer(), SegmentExecutionMode.SLOW)).isEqualTo("\"slow\"")
+    assertThat(json.encodeToString(SegmentExecutionMode.serializer(), SegmentExecutionMode.LOOP)).isEqualTo("\"loop\"")
+    assertThat(json.encodeToString(SegmentExecutionMode.serializer(), SegmentExecutionMode.ASSERTION_ONLY))
+      .isEqualTo("\"assertion-only\"")
+
+    assertThat(json.decodeFromString(SegmentExecutionMode.serializer(), "\"fast\"")).isEqualTo(SegmentExecutionMode.FAST)
+    assertThat(json.decodeFromString(SegmentExecutionMode.serializer(), "\"slow\"")).isEqualTo(SegmentExecutionMode.SLOW)
+    assertThat(json.decodeFromString(SegmentExecutionMode.serializer(), "\"loop\"")).isEqualTo(SegmentExecutionMode.LOOP)
+    assertThat(json.decodeFromString(SegmentExecutionMode.serializer(), "\"assertion-only\""))
+      .isEqualTo(SegmentExecutionMode.ASSERTION_ONLY)
+  }
+
+  @Test
+  fun `evidence type encodes and decodes all stable wire values`() {
+    assertThat(json.encodeToString(EvidenceType.serializer(), EvidenceType.FLOW)).isEqualTo("\"flow\"")
+    assertThat(json.encodeToString(EvidenceType.serializer(), EvidenceType.SCREENSHOT)).isEqualTo("\"screenshot\"")
+    assertThat(json.encodeToString(EvidenceType.serializer(), EvidenceType.HIERARCHY)).isEqualTo("\"hierarchy\"")
+
+    assertThat(json.decodeFromString(EvidenceType.serializer(), "\"flow\"")).isEqualTo(EvidenceType.FLOW)
+    assertThat(json.decodeFromString(EvidenceType.serializer(), "\"screenshot\"")).isEqualTo(EvidenceType.SCREENSHOT)
+    assertThat(json.decodeFromString(EvidenceType.serializer(), "\"hierarchy\"")).isEqualTo(EvidenceType.HIERARCHY)
+  }
+
+  @Test
+  fun `artifact error kind encodes and decodes all stable wire values`() {
+    assertThat(json.encodeToString(ArtifactErrorKind.serializer(), ArtifactErrorKind.PARSER_FAILURE))
+      .isEqualTo("\"parser_failure\"")
+    assertThat(json.encodeToString(ArtifactErrorKind.serializer(), ArtifactErrorKind.SETUP_FAILURE))
+      .isEqualTo("\"setup_failure\"")
+    assertThat(json.encodeToString(ArtifactErrorKind.serializer(), ArtifactErrorKind.JOURNEY_FAILURE))
+      .isEqualTo("\"journey_failure\"")
+
+    assertThat(json.decodeFromString(ArtifactErrorKind.serializer(), "\"parser_failure\""))
+      .isEqualTo(ArtifactErrorKind.PARSER_FAILURE)
+    assertThat(json.decodeFromString(ArtifactErrorKind.serializer(), "\"setup_failure\""))
+      .isEqualTo(ArtifactErrorKind.SETUP_FAILURE)
+    assertThat(json.decodeFromString(ArtifactErrorKind.serializer(), "\"journey_failure\""))
+      .isEqualTo(ArtifactErrorKind.JOURNEY_FAILURE)
+  }
 }

--- a/verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt
+++ b/verity/core/src/test/kotlin/me/chrisbanes/verity/core/result/RunResultContractTest.kt
@@ -68,6 +68,7 @@ class RunResultContractTest {
         SuiteJourneyArtifact(path = "journeys/002-browse.json", name = "Browse", status = ArtifactStatus.FAILED),
       ),
       error = ArtifactError(kind = ArtifactErrorKind.JOURNEY_FAILURE, message = "One or more journeys failed"),
+      platform = Platform.IOS,
     )
 
     val encoded = json.encodeToString(SuiteArtifactSummary.serializer(), summary)
@@ -77,6 +78,28 @@ class RunResultContractTest {
     assertThat(encoded).contains("\"passed\":1")
     assertThat(encoded).contains("\"failed\":1")
     assertThat(encoded).contains("\"path\":\"journeys/001-login.json\"")
+    assertThat(encoded).contains("\"platform\":\"ios\"")
+  }
+
+  @Test
+  fun `suite summary decodes stable platform wire value`() {
+    val decoded = json.decodeFromString(
+      SuiteArtifactSummary.serializer(),
+      """
+      {
+        "formatVersion":1,
+        "timestamp":"2026-07-08T14:35:12Z",
+        "inputPath":"journeys",
+        "status":"passed",
+        "total":1,
+        "passed":1,
+        "failed":0,
+        "platform":"ios"
+      }
+      """.trimIndent(),
+    )
+
+    assertThat(decoded.platform).isEqualTo(Platform.IOS)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add stable run artifact result contracts and segment metadata capture for generated flows and evidence.
- Persist timestamped run directories with per-journey JSON, suite summaries, generated flows, and evidence references.
- Add CI-friendly exit-code handling for parser, setup/artifact, and journey failures, plus architecture docs.

## Test Plan
- [x] rtk ./gradlew spotlessApply
- [x] rtk ./gradlew check

Closes #49