### PR TITLE
Add dry-run mode for journey execution

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 Verity is a Kotlin/JVM tool that combines device automation (Maestro SDK) with LLM reasoning (via Koog) to run end-to-end journey tests on Android TV, Android mobile, and iOS devices. It operates in two modes:
 
-1. **CLI mode** (`verity run`) — Executes journey YAML files against a connected device, using LLMs to generate Maestro flows and evaluate assertions.
+1. **CLI mode** (`verity run`) — Executes journey YAML files against a connected device, using LLMs to generate Maestro flows and evaluate assertions. `verity run --dry-run` parses, segments, renders fast-path actions, and generates slow-path Maestro YAML without device access.
 2. **MCP server mode** (`verity mcp`) — Exposes device control as MCP tools so an AI agent can interactively drive the device.
 
 LLMs serve two purposes: flow generation (turning English into Maestro YAML) and assertion evaluation (judging whether screen state matches an expectation). Deterministic fast-paths handle both when possible, so LLM calls happen only when necessary.
@@ -177,6 +177,12 @@ data class JourneySegment(
 - Trailing actions without an assertion become a final segment
 
 Each segment is a natural checkpoint: run actions, evaluate assertion, stop on failure.
+
+### Dry-Run Planning
+
+`verity run --dry-run` reuses normal journey resolution and segmentation, then switches to a CLI-owned planner instead of `Orchestrator`. The planner renders the launch flow, classifies fast-path action groups with `InteractionMapper`, generates Maestro YAML for slow-path action groups with `NavigatorAgent`, and records assertion descriptions and modes without evaluating them.
+
+Dry-run always prints a Markdown report and writes per-journey artifacts under `<output-path>/dry-run`. It may call the navigator LLM for slow-path YAML, but it does not run device preflight, create `DeviceSession`, execute flows, capture hierarchy, capture screenshots, or evaluate assertions.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-08-dry-run-mode.md
+++ b/docs/superpowers/plans/2026-07-08-dry-run-mode.md
@@ -1,0 +1,1149 @@
+# Dry-Run Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `verity run --dry-run` so journey authors can inspect parsing, segmentation, fast-path classification, and generated slow-path Maestro YAML without device access.
+
+**Architecture:** Keep dry-run as a CLI-owned planning path, separate from `Orchestrator` and `DeviceSession`. `RunCommand` resolves journeys exactly as normal, then dry-run builds a report with `JourneySegmenter`, `InteractionMapper`, lazy navigator generation, a Markdown renderer, and an artifact writer.
+
+**Tech Stack:** Kotlin/JVM 21, Clikt, kotlinx-coroutines, Koog for navigator generation, assertk, kotlinx-coroutines-test, Gradle via `./gradlew`.
+
+---
+
+## File Structure
+
+- Create `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunPlanner.kt`: dry-run report models, planner, navigator abstraction, and interaction descriptions.
+- Create `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunRenderer.kt`: one Markdown renderer shared by stdout and artifact files.
+- Create `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriter.kt`: writes one Markdown file per journey under `<output-path>/dry-run` using `Dispatchers.IO`.
+- Modify `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/CliPreflightChecker.kt`: allow provider/model/path/temp preflight without device preflight.
+- Modify `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`: add `--dry-run`, branch after journey resolution, load context, lazily preflight provider/model only when navigator YAML is needed, print reports, and write artifacts.
+- Modify `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/CliPreflightCheckerTest.kt`: cover skipped device preflight.
+- Create `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt`: cover fast path, slow path, loops, assertions, and lazy navigator behavior.
+- Create `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriterTest.kt`: cover artifact path and content.
+- Modify `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`: cover CLI dry-run behavior and no normal suite runner call.
+- Modify `docs/architecture.md`: document `verity run --dry-run`.
+
+### Task 1: Add Device-Preflight Skip Support
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/CliPreflightChecker.kt`
+- Modify: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/CliPreflightCheckerTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `CliPreflightCheckerTest` after `runs device preflight for selected platform`:
+
+```kotlin
+@Test
+fun `can skip device preflight for dry run`() = runTest {
+  val journey = Files.createTempFile("journey-", ".journey.yaml")
+  var devicePreflightCalls = 0
+  val checker = CliPreflightChecker(
+    environment = { name -> if (name == "ANTHROPIC_API_KEY") "secret" else null },
+    devicePreflightChecker = DevicePreflightChecker { _, _ ->
+      devicePreflightCalls += 1
+      PreflightReport()
+    },
+  )
+
+  val result = checker.check(
+    request = CliPreflightRequest(
+      cliProvider = "anthropic",
+      cliNavigatorModel = null,
+      cliInspectorModel = null,
+      apiKey = null,
+      journeyPath = journey.toString(),
+      contextPath = null,
+      platform = Platform.ANDROID_TV,
+      deviceId = null,
+    ),
+    config = VerityConfig(),
+    includeDevicePreflight = false,
+  )
+
+  assertThat(result.report.passed).isTrue()
+  assertThat(devicePreflightCalls).isEqualTo(0)
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.CliPreflightCheckerTest`
+
+Expected: compilation fails because `check` has no `includeDevicePreflight` parameter.
+
+- [ ] **Step 3: Implement the minimal preflight flag**
+
+In `CliPreflightChecker.kt`, change the `check` signature and device preflight line to:
+
+```kotlin
+suspend fun check(
+  request: CliPreflightRequest,
+  config: VerityConfig,
+  includeDevicePreflight: Boolean = true,
+): CliPreflightResult {
+```
+
+Replace:
+
+```kotlin
+report += devicePreflightChecker.check(request.platform, request.deviceId)
+```
+
+with:
+
+```kotlin
+if (includeDevicePreflight) {
+  report += devicePreflightChecker.check(request.platform, request.deviceId)
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.CliPreflightCheckerTest`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/CliPreflightChecker.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/CliPreflightCheckerTest.kt
+git commit -m "feat: allow CLI preflight without device checks"
+```
+
+### Task 2: Add Dry-Run Planner Models And Fast-Path Planning
+
+**Files:**
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunPlanner.kt`
+- Create: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt`
+
+- [ ] **Step 1: Write failing planner tests for fast-path-only journeys**
+
+Create `DryRunPlannerTest.kt` with:
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Journey
+import me.chrisbanes.verity.core.model.JourneyStep
+import me.chrisbanes.verity.core.model.Platform
+
+class DryRunPlannerTest {
+  @Test
+  fun `fast path actions are represented without invoking navigator`() = runTest {
+    var navigatorCalls = 0
+    val planner = DryRunPlanner(
+      navigatorFactory = {
+        navigatorCalls += 1
+        DryRunNavigator { _, _, _, _ -> error("navigator should not be called") }
+      },
+    )
+    val journey = Journey(
+      name = "Fast journey",
+      app = "com.example.app",
+      platform = Platform.ANDROID_TV,
+      steps = listOf(
+        JourneyStep.Action("press d-pad down"),
+        JourneyStep.Action("press select"),
+        JourneyStep.Assert("Home", AssertMode.VISIBLE),
+      ),
+    )
+
+    val report = planner.plan(resolvedJourney(journey))
+
+    assertThat(navigatorCalls).isEqualTo(0)
+    assertThat(report.launchYaml).isEqualTo("appId: com.example.app\n---\n- launchApp")
+    assertThat(report.segments).transform { it.size }.isEqualTo(1)
+    val segment = report.segments.single()
+    assertThat(segment.index).isEqualTo(0)
+    assertThat(segment.actions?.kind).isEqualTo(DryRunExecutionKind.FAST_PATH)
+    assertThat(segment.actions?.instructions).containsExactly("press d-pad down", "press select")
+    assertThat(segment.actions?.interactions.orEmpty()).contains("KeyPress(DPAD_DOWN)")
+    assertThat(segment.actions?.yaml).isNull()
+    assertThat(segment.assertion?.description).isEqualTo("Home")
+    assertThat(segment.assertion?.mode).isEqualTo(AssertMode.VISIBLE)
+  }
+
+  private fun resolvedJourney(journey: Journey): ResolvedJourney = ResolvedJourney(
+    file = java.io.File("${journey.name}.journey.yaml"),
+    journey = journey,
+  )
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.DryRunPlannerTest`
+
+Expected: compilation fails because dry-run planner types do not exist.
+
+- [ ] **Step 3: Implement planner models and fast-path planning**
+
+Create `DryRunPlanner.kt`:
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import me.chrisbanes.verity.core.interaction.Interaction
+import me.chrisbanes.verity.core.interaction.InteractionMapper
+import me.chrisbanes.verity.core.journey.JourneySegmenter
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Journey
+import me.chrisbanes.verity.core.model.JourneySegment
+import me.chrisbanes.verity.core.model.Platform
+
+fun interface DryRunNavigator {
+  suspend fun generate(
+    actions: List<String>,
+    appId: String,
+    platform: Platform,
+    context: String,
+  ): String
+}
+
+enum class DryRunExecutionKind {
+  FAST_PATH,
+  SLOW_PATH,
+}
+
+data class DryRunSuiteReport(
+  val journeys: List<DryRunJourneyReport>,
+)
+
+data class DryRunJourneyReport(
+  val resolvedJourney: ResolvedJourney,
+  val launchYaml: String,
+  val segments: List<DryRunSegmentReport>,
+  val artifactFile: java.io.File? = null,
+)
+
+data class DryRunSegmentReport(
+  val index: Int,
+  val actions: DryRunActionGroupReport? = null,
+  val loop: DryRunLoopReport? = null,
+  val assertion: DryRunAssertionReport? = null,
+)
+
+data class DryRunActionGroupReport(
+  val instructions: List<String>,
+  val kind: DryRunExecutionKind,
+  val interactions: List<String> = emptyList(),
+  val yaml: String? = null,
+)
+
+data class DryRunLoopReport(
+  val action: String,
+  val until: String,
+  val max: Int,
+  val kind: DryRunExecutionKind,
+  val interaction: String? = null,
+  val yaml: String? = null,
+)
+
+data class DryRunAssertionReport(
+  val description: String,
+  val mode: AssertMode,
+)
+
+class DryRunPlanner(
+  private val navigatorFactory: suspend () -> DryRunNavigator,
+  private val context: String = "",
+) {
+  private var navigator: DryRunNavigator? = null
+
+  suspend fun plan(resolvedJourney: ResolvedJourney): DryRunJourneyReport {
+    val journey = resolvedJourney.journey
+    return DryRunJourneyReport(
+      resolvedJourney = resolvedJourney,
+      launchYaml = launchYaml(journey),
+      segments = JourneySegmenter.segment(journey.steps).map { segment -> planSegment(segment, journey) },
+    )
+  }
+
+  private suspend fun planSegment(segment: JourneySegment, journey: Journey): DryRunSegmentReport = DryRunSegmentReport(
+    index = segment.index,
+    actions = planActions(segment.actions.map { it.instruction }, journey),
+    loop = segment.loop?.let { loop ->
+      val mapper = InteractionMapper.forPlatform(journey.platform)
+      val interaction = mapper.map(loop.action)
+      if (interaction != null) {
+        DryRunLoopReport(
+          action = loop.action,
+          until = loop.until,
+          max = loop.max,
+          kind = DryRunExecutionKind.FAST_PATH,
+          interaction = describeInteraction(interaction),
+        )
+      } else {
+        DryRunLoopReport(
+          action = loop.action,
+          until = loop.until,
+          max = loop.max,
+          kind = DryRunExecutionKind.SLOW_PATH,
+          yaml = navigator().generate(listOf(loop.action), journey.app, journey.platform, context),
+        )
+      }
+    },
+    assertion = segment.assertion?.let { DryRunAssertionReport(it.description, it.mode) },
+  )
+
+  private suspend fun planActions(instructions: List<String>, journey: Journey): DryRunActionGroupReport? {
+    if (instructions.isEmpty()) return null
+
+    val mapper = InteractionMapper.forPlatform(journey.platform)
+    val interactions = instructions.map { mapper.map(it) }
+    return if (interactions.all { it != null }) {
+      DryRunActionGroupReport(
+        instructions = instructions,
+        kind = DryRunExecutionKind.FAST_PATH,
+        interactions = interactions.filterNotNull().map(::describeInteraction),
+      )
+    } else {
+      DryRunActionGroupReport(
+        instructions = instructions,
+        kind = DryRunExecutionKind.SLOW_PATH,
+        yaml = navigator().generate(instructions, journey.app, journey.platform, context),
+      )
+    }
+  }
+
+  private suspend fun navigator(): DryRunNavigator = navigator ?: navigatorFactory().also { navigator = it }
+
+  private fun launchYaml(journey: Journey): String = "appId: ${journey.app}\n---\n- launchApp"
+
+  private fun describeInteraction(interaction: Interaction): String = when (interaction) {
+    is Interaction.KeyPress -> "KeyPress(${interaction.keyName})"
+    is Interaction.TapOnText -> "TapOnText(${interaction.text})"
+    is Interaction.TapOnId -> "TapOnId(${interaction.resourceId})"
+    is Interaction.Scroll -> "Scroll(${interaction.direction})"
+    is Interaction.Swipe -> "Swipe(${interaction.direction})"
+    Interaction.LongPressOnFocused -> "LongPressOnFocused"
+    is Interaction.LongPressOnText -> "LongPressOnText(${interaction.text})"
+    Interaction.PullToRefresh -> "PullToRefresh"
+  }
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.DryRunPlannerTest`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunPlanner.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt
+git commit -m "feat: add dry-run planner fast path reports"
+```
+
+### Task 3: Add Slow-Path And Loop Planner Coverage
+
+**Files:**
+- Modify: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt`
+
+- [ ] **Step 1: Add slow-path and loop tests**
+
+Append these tests inside `DryRunPlannerTest` before the helper function:
+
+```kotlin
+@Test
+fun `slow path actions include generated yaml`() = runTest {
+  val planner = DryRunPlanner(
+    navigatorFactory = {
+      DryRunNavigator { actions, appId, platform, context ->
+        assertThat(actions).containsExactly("complete onboarding wizard")
+        assertThat(appId).isEqualTo("com.example.app")
+        assertThat(platform).isEqualTo(Platform.ANDROID_MOBILE)
+        assertThat(context).isEqualTo("project context")
+        "appId: com.example.app\n---\n- tapOn: \"Settings\""
+      }
+    },
+    context = "project context",
+  )
+  val journey = Journey(
+    name = "Slow journey",
+    app = "com.example.app",
+    platform = Platform.ANDROID_MOBILE,
+    steps = listOf(JourneyStep.Action("complete onboarding wizard")),
+  )
+
+  val segment = planner.plan(resolvedJourney(journey)).segments.single()
+
+  assertThat(segment.actions?.kind).isEqualTo(DryRunExecutionKind.SLOW_PATH)
+  assertThat(segment.actions?.yaml).isEqualTo("appId: com.example.app\n---\n- tapOn: \"Settings\"")
+}
+
+@Test
+fun `loop reports fast path mapping when action maps`() = runTest {
+  val planner = DryRunPlanner(
+    navigatorFactory = { DryRunNavigator { _, _, _, _ -> error("navigator should not be called") } },
+  )
+  val journey = Journey(
+    name = "Loop journey",
+    app = "com.example.app",
+    platform = Platform.ANDROID_TV,
+    steps = listOf(JourneyStep.Loop(action = "press d-pad down", until = "Settings", max = 3)),
+  )
+
+  val loop = planner.plan(resolvedJourney(journey)).segments.single().loop
+
+  assertThat(loop?.kind).isEqualTo(DryRunExecutionKind.FAST_PATH)
+  assertThat(loop?.action).isEqualTo("press d-pad down")
+  assertThat(loop?.until).isEqualTo("Settings")
+  assertThat(loop?.max).isEqualTo(3)
+  assertThat(loop?.interaction).isEqualTo("KeyPress(DPAD_DOWN)")
+  assertThat(loop?.yaml).isNull()
+}
+
+@Test
+fun `loop reports generated yaml when action does not map`() = runTest {
+  val planner = DryRunPlanner(
+    navigatorFactory = {
+      DryRunNavigator { actions, _, _, _ ->
+        assertThat(actions).containsExactly("navigate to settings page")
+        "appId: com.example.app\n---\n- tapOn: \"Settings\""
+      }
+    },
+  )
+  val journey = Journey(
+    name = "Slow loop journey",
+    app = "com.example.app",
+    platform = Platform.ANDROID_MOBILE,
+    steps = listOf(JourneyStep.Loop(action = "navigate to settings page", until = "Settings", max = 2)),
+  )
+
+  val loop = planner.plan(resolvedJourney(journey)).segments.single().loop
+
+  assertThat(loop?.kind).isEqualTo(DryRunExecutionKind.SLOW_PATH)
+  assertThat(loop?.yaml).isEqualTo("appId: com.example.app\n---\n- tapOn: \"Settings\"")
+}
+```
+
+- [ ] **Step 2: Run the targeted tests**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.DryRunPlannerTest`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt
+git commit -m "test: cover dry-run slow path planning"
+```
+
+### Task 4: Add Markdown Renderer
+
+**Files:**
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunRenderer.kt`
+- Modify: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt`
+
+- [ ] **Step 1: Add renderer test**
+
+Add this test inside `DryRunPlannerTest`:
+
+```kotlin
+@Test
+fun `renderer includes launch yaml segments fast path slow path loops and assertions`() = runTest {
+  val report = DryRunJourneyReport(
+    resolvedJourney = resolvedJourney(
+      Journey(
+        name = "Rendered journey",
+        app = "com.example.app",
+        platform = Platform.ANDROID_MOBILE,
+        steps = emptyList(),
+      ),
+    ),
+    launchYaml = "appId: com.example.app\n---\n- launchApp",
+    segments = listOf(
+      DryRunSegmentReport(
+        index = 0,
+        actions = DryRunActionGroupReport(
+          instructions = listOf("tap Settings"),
+          kind = DryRunExecutionKind.FAST_PATH,
+          interactions = listOf("TapOnText(Settings)"),
+        ),
+        assertion = DryRunAssertionReport("Settings", AssertMode.VISIBLE),
+      ),
+      DryRunSegmentReport(
+        index = 1,
+        actions = DryRunActionGroupReport(
+          instructions = listOf("open account details"),
+          kind = DryRunExecutionKind.SLOW_PATH,
+          yaml = "appId: com.example.app\n---\n- tapOn: \"Account\"",
+        ),
+        loop = DryRunLoopReport(
+          action = "navigate to logout",
+          until = "Logout",
+          max = 2,
+          kind = DryRunExecutionKind.SLOW_PATH,
+          yaml = "appId: com.example.app\n---\n- scroll",
+        ),
+      ),
+    ),
+  )
+
+  val markdown = DryRunRenderer.renderJourney(report)
+
+  assertThat(markdown).contains("# Dry Run: Rendered journey")
+  assertThat(markdown).contains("File: Rendered journey.journey.yaml")
+  assertThat(markdown).contains("Platform: ANDROID_MOBILE")
+  assertThat(markdown).contains("## Launch Flow")
+  assertThat(markdown).contains("```yaml\nappId: com.example.app\n---\n- launchApp\n```")
+  assertThat(markdown).contains("## Segment 0")
+  assertThat(markdown).contains("Kind: FAST_PATH")
+  assertThat(markdown).contains("TapOnText(Settings)")
+  assertThat(markdown).contains("Assertion: [VISIBLE] Settings")
+  assertThat(markdown).contains("Kind: SLOW_PATH")
+  assertThat(markdown).contains("Loop: navigate to logout until Logout, max 2")
+  assertThat(markdown).contains("- scroll")
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.DryRunPlannerTest`
+
+Expected: compilation fails because `DryRunRenderer` does not exist.
+
+- [ ] **Step 3: Implement renderer**
+
+Create `DryRunRenderer.kt`:
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+object DryRunRenderer {
+  fun renderJourney(report: DryRunJourneyReport): String = buildString {
+    val resolved = report.resolvedJourney
+    val journey = resolved.journey
+    appendLine("# Dry Run: ${journey.name}")
+    appendLine()
+    appendLine("File: ${resolved.file.path}")
+    appendLine("App: ${journey.app}")
+    appendLine("Platform: ${journey.platform}")
+    report.artifactFile?.let { appendLine("Artifact: ${it.path}") }
+    appendLine()
+    appendLine("## Launch Flow")
+    appendYaml(report.launchYaml)
+    report.segments.forEach { segment ->
+      appendLine()
+      appendLine("## Segment ${segment.index}")
+      segment.actions?.let { actions ->
+        appendLine()
+        appendLine("Actions:")
+        actions.instructions.forEach { appendLine("- $it") }
+        appendLine("Kind: ${actions.kind}")
+        if (actions.interactions.isNotEmpty()) {
+          appendLine("Interactions:")
+          actions.interactions.forEach { appendLine("- $it") }
+        }
+        actions.yaml?.let {
+          appendLine("Generated YAML:")
+          appendYaml(it)
+        }
+      }
+      segment.loop?.let { loop ->
+        appendLine()
+        appendLine("Loop: ${loop.action} until ${loop.until}, max ${loop.max}")
+        appendLine("Kind: ${loop.kind}")
+        loop.interaction?.let { appendLine("Interaction: $it") }
+        loop.yaml?.let {
+          appendLine("Generated Loop YAML:")
+          appendYaml(it)
+        }
+      }
+      segment.assertion?.let { assertion ->
+        appendLine()
+        appendLine("Assertion: [${assertion.mode}] ${assertion.description}")
+      }
+    }
+  }.trimEnd()
+
+  fun renderSuite(report: DryRunSuiteReport): String = report.journeys
+    .joinToString(separator = "\n\n---\n\n") { renderJourney(it) }
+
+  private fun StringBuilder.appendYaml(yaml: String) {
+    appendLine("```yaml")
+    appendLine(yaml.trimEnd())
+    appendLine("```")
+  }
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.DryRunPlannerTest`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunRenderer.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt
+git commit -m "feat: render dry-run reports"
+```
+
+### Task 5: Add Artifact Writer
+
+**Files:**
+- Create: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriter.kt`
+- Create: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriterTest.kt`
+
+- [ ] **Step 1: Write failing artifact test**
+
+Create `DryRunArtifactWriterTest.kt`:
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.endsWith
+import assertk.assertions.isEqualTo
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import me.chrisbanes.verity.core.model.Journey
+import me.chrisbanes.verity.core.model.Platform
+
+class DryRunArtifactWriterTest {
+  @Test
+  fun `writes one markdown artifact per journey under dry run directory`() = runTest {
+    val output = createTempDirectory("verity-dry-run-output").toFile()
+    try {
+      val journey = Journey(
+        name = "Artifact journey",
+        app = "com.example.app",
+        platform = Platform.ANDROID_TV,
+        steps = emptyList(),
+      )
+      val report = DryRunJourneyReport(
+        resolvedJourney = ResolvedJourney(File("artifact.journey.yaml"), journey),
+        launchYaml = "appId: com.example.app\n---\n- launchApp",
+        segments = emptyList(),
+      )
+
+      val suite = DryRunArtifactWriter().write(output, DryRunSuiteReport(listOf(report)))
+
+      val written = suite.journeys.single().artifactFile
+      assertThat(written?.path.orEmpty()).endsWith("dry-run/artifact.md")
+      assertThat(written?.readText().orEmpty()).contains("# Dry Run: Artifact journey")
+      assertThat(written?.readText().orEmpty()).contains("Artifact: ${written?.path}")
+      assertThat(suite.journeys.single().resolvedJourney).isEqualTo(report.resolvedJourney)
+    } finally {
+      output.deleteRecursively()
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.DryRunArtifactWriterTest`
+
+Expected: compilation fails because `DryRunArtifactWriter` does not exist.
+
+- [ ] **Step 3: Implement artifact writer**
+
+Create `DryRunArtifactWriter.kt`:
+
+```kotlin
+package me.chrisbanes.verity.cli
+
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class DryRunArtifactWriter {
+  suspend fun write(
+    outputPath: File,
+    suiteReport: DryRunSuiteReport,
+  ): DryRunSuiteReport = withContext(Dispatchers.IO) {
+    val directory = File(outputPath, "dry-run")
+    directory.mkdirs()
+
+    DryRunSuiteReport(
+      journeys = suiteReport.journeys.map { report ->
+        val file = File(directory, artifactName(report.resolvedJourney.file))
+        val reportWithArtifact = report.copy(artifactFile = file)
+        file.writeText(DryRunRenderer.renderJourney(reportWithArtifact))
+        reportWithArtifact
+      },
+    )
+  }
+
+  private fun artifactName(file: File): String {
+    val name = file.name
+    return when {
+      name.endsWith(".journey.yaml") -> name.removeSuffix(".journey.yaml") + ".md"
+      name.endsWith(".yaml") -> name.removeSuffix(".yaml") + ".md"
+      else -> file.nameWithoutExtension + ".md"
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.DryRunArtifactWriterTest`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriter.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriterTest.kt
+git commit -m "feat: write dry-run artifacts"
+```
+
+### Task 6: Wire Dry-Run Into RunCommand With Injectable Test Boundary
+
+**Files:**
+- Modify: `verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt`
+- Modify: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`
+
+- [ ] **Step 1: Add CLI tests for dry-run branch and artifact output**
+
+In `RunCommandTest.kt`, add imports:
+
+```kotlin
+import assertk.assertions.doesNotContain
+import assertk.assertions.exists
+import me.chrisbanes.verity.core.model.Platform
+```
+
+Add this helper after the existing `runCommand` helper:
+
+```kotlin
+private fun dryRunCommand(
+  runner: suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport,
+): RunCommand = RunCommand(dryRunSuiteRunner = runner)
+```
+
+Add these tests before the helper functions:
+
+```kotlin
+@Test
+fun `dry run uses dry-run runner and does not call normal suite runner`() {
+  val dir = createTempDirectory("verity-run-dry").toFile()
+  try {
+    val output = File(dir, "out")
+    val file = writeJourney(dir, "dry.journey.yaml", "Dry journey")
+    var dryRunCalled = false
+    val command = RunCommand(
+      suiteRunner = { error("normal suite runner should not be called") },
+      dryRunSuiteRunner = { journeys, outputPath ->
+        dryRunCalled = true
+        assertThat(journeys.map { it.file.name }).containsExactly("dry.journey.yaml")
+        assertThat(outputPath).isEqualTo(output)
+        DryRunSuiteReport(
+          journeys = listOf(
+            DryRunJourneyReport(
+              resolvedJourney = journeys.single(),
+              launchYaml = "appId: com.example.app\n---\n- launchApp",
+              segments = emptyList(),
+              artifactFile = File(output, "dry-run/dry.md"),
+            ),
+          ),
+        )
+      },
+    )
+
+    val result = Verity()
+      .subcommands(command)
+      .test(listOf("--output-path", output.absolutePath, "run", "--dry-run", file.absolutePath))
+
+    assertThat(result.statusCode).isEqualTo(0)
+    assertThat(dryRunCalled).isEqualTo(true)
+    assertThat(result.output).contains("# Dry Run: Dry journey")
+    assertThat(result.output).contains("Artifact: ${File(output, "dry-run/dry.md").path}")
+    assertThat(result.output).doesNotContain("Suite result:")
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+
+@Test
+fun `dry run writes artifacts with production dry-run runner`() {
+  val dir = createTempDirectory("verity-run-dry-artifact").toFile()
+  try {
+    val output = File(dir, "out")
+    val file = writeJourneyWithSteps(
+      dir = dir,
+      name = "fast.journey.yaml",
+      journeyName = "Fast dry journey",
+      steps = listOf("press d-pad down", "[?] Home"),
+    )
+
+    val result = Verity()
+      .subcommands(RunCommand())
+      .test(listOf("--output-path", output.absolutePath, "run", "--dry-run", file.absolutePath))
+
+    val artifact = File(output, "dry-run/fast.md")
+    assertThat(result.statusCode).isEqualTo(0)
+    assertThat(artifact).exists()
+    assertThat(artifact.readText()).contains("# Dry Run: Fast dry journey")
+    assertThat(result.output).contains("KeyPress(DPAD_DOWN)")
+    assertThat(result.output).contains("Assertion: [VISIBLE] Home")
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+```
+
+Add this helper after `writeJourney`:
+
+```kotlin
+private fun writeJourneyWithSteps(
+  dir: File,
+  name: String,
+  journeyName: String,
+  platform: String = "android-tv",
+  steps: List<String>,
+): File {
+  val file = File(dir, name)
+  file.writeText(
+    buildString {
+      appendLine("name: $journeyName")
+      appendLine("app: com.example.app")
+      appendLine("platform: $platform")
+      appendLine()
+      appendLine("steps:")
+      steps.forEach { step -> appendLine("  - \"${step.replace("\\", "\\\\").replace("\"", "\\\"")}\"") }
+    },
+  )
+  return file
+}
+```
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandTest`
+
+Expected: compilation fails because `dryRunSuiteRunner`, `--dry-run`, and production dry-run wiring do not exist.
+
+- [ ] **Step 3: Add constructor seam and option in RunCommand**
+
+In `RunCommand.kt`, add imports:
+
+```kotlin
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+```
+
+Change the constructor to:
+
+```kotlin
+class RunCommand(
+  private val loadJourney: (File, AssertionStrategy) -> Journey = JourneyLoader::fromFile,
+  private val listJourneyFiles: (File) -> List<File> = JourneyLoader::listJourneyFiles,
+  private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
+  private val dryRunSuiteRunner: (suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport)? = null,
+) : CliktCommand(name = "run") {
+```
+
+Add the option near `journeyPath`:
+
+```kotlin
+private val dryRun by option("--dry-run", help = "Validate journeys and render generated Maestro YAML without device access").flag()
+```
+
+- [ ] **Step 4: Branch to dry-run in `run()`**
+
+In `RunCommand.run()`, after `journeys` is resolved and before `suiteRunner?.invoke(journeys)`, add:
+
+```kotlin
+if (dryRun) {
+  val dryRunReport = dryRunSuiteRunner?.invoke(journeys, resolved.outputPath)
+    ?: runDryRun(
+      parent = parent,
+      config = config,
+      resolved = resolved,
+      path = path,
+      journeys = journeys,
+    )
+  echo(DryRunRenderer.renderSuite(dryRunReport))
+  return@runBlocking
+}
+```
+
+- [ ] **Step 5: Add production dry-run method with lazy navigator preflight**
+
+Add this method inside `RunCommand` before `printSuiteResult`:
+
+```kotlin
+private suspend fun runDryRun(
+  parent: Verity,
+  config: VerityConfig,
+  resolved: ResolvedProjectConfig,
+  path: File,
+  journeys: List<ResolvedJourney>,
+): DryRunSuiteReport {
+  val contextDir = resolved.contextPath
+  val requireContext = resolveRequiredContext(parent.requireContext, config)
+  val projectContext = try {
+    withContext(Dispatchers.IO) {
+      ContextLoader.loadProject(directory = contextDir, required = requireContext)
+    }
+  } catch (e: ContextValidationException) {
+    throw CliktError(e.message ?: "Project context validation failed")
+  }
+  projectContext.describeForCli(contextDir, requireContext).forEach { echo(it) }
+
+  var dryRunNavigator: DryRunNavigator? = null
+  val planner = DryRunPlanner(
+    context = projectContext.text,
+    navigatorFactory = {
+      dryRunNavigator ?: createDryRunNavigator(parent, config, resolved, path, journeys.first().journey.platform)
+        .also { dryRunNavigator = it }
+    },
+  )
+  val suiteReport = DryRunSuiteReport(journeys.map { resolvedJourney -> planner.plan(resolvedJourney) })
+  return DryRunArtifactWriter().write(resolved.outputPath, suiteReport)
+}
+```
+
+Add this method after `runDryRun`:
+
+```kotlin
+private suspend fun createDryRunNavigator(
+  parent: Verity,
+  config: VerityConfig,
+  resolved: ResolvedProjectConfig,
+  path: File,
+  platform: Platform,
+): DryRunNavigator {
+  val preflight = CliPreflightChecker().check(
+    request = CliPreflightRequest(
+      cliProvider = parent.provider,
+      cliNavigatorModel = parent.navigatorModel,
+      cliInspectorModel = parent.inspectorModel,
+      apiKey = parent.apiKey,
+      journeyPath = path.path,
+      contextPath = null,
+      platform = platform,
+      deviceId = resolved.deviceId,
+    ),
+    config = config,
+    includeDevicePreflight = false,
+  )
+  if (!preflight.report.passed) {
+    throw CliktError(preflight.report.renderPlainText())
+  }
+
+  val provider = checkNotNull(preflight.provider)
+  val navigatorModel = checkNotNull(preflight.navigatorModel)
+  val executor = MultiLLMPromptExecutor(provider.createClient(preflight.apiKey.orEmpty()))
+  val navigatorAgent = NavigatorAgent(
+    bundledContext = if (parent.noBundledContext) "" else ContextLoader.loadBundled(),
+    agentFactory = { systemPrompt ->
+      AIAgent(
+        promptExecutor = executor,
+        llmModel = navigatorModel,
+        systemPrompt = systemPrompt,
+      )
+    },
+  )
+  return DryRunNavigator { actions, appId, targetPlatform, context ->
+    try {
+      navigatorAgent.generate(actions, appId, targetPlatform, context)
+    } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      throw CliktError("Dry-run YAML generation failed for ${actions.joinToString()}: ${e.message}")
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Run targeted tests to verify they pass**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandTest`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+git commit -m "feat: wire dry-run into run command"
+```
+
+### Task 7: Add Invalid Journey And Directory Dry-Run Tests
+
+**Files:**
+- Modify: `verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt`
+
+- [ ] **Step 1: Add acceptance tests for parser errors and directory behavior**
+
+Add these tests to `RunCommandTest.kt`:
+
+```kotlin
+@Test
+fun `dry run invalid journey fails before dry-run runner`() {
+  val dir = createTempDirectory("verity-run-dry-invalid").toFile()
+  try {
+    val file = File(dir, "invalid.journey.yaml")
+    file.writeText("name: Invalid\nsteps: not-a-list")
+
+    val result = Verity()
+      .subcommands(dryRunCommand { _, _ -> error("dry-run runner should not be called") })
+      .test("run --dry-run ${file.absolutePath}")
+
+    assertThat(result.statusCode).isEqualTo(1)
+    assertThat(result.output).contains("invalid.journey.yaml")
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+
+@Test
+fun `directory dry run resolves files in sorted order`() {
+  val dir = createTempDirectory("verity-run-dry-directory").toFile()
+  try {
+    writeJourney(dir, "b.journey.yaml", "Second")
+    writeJourney(dir, "a.journey.yaml", "First")
+    val seen = mutableListOf<String>()
+
+    val result = Verity()
+      .subcommands(dryRunCommand { journeys, _ ->
+        seen += journeys.map { it.file.name }
+        DryRunSuiteReport(
+          journeys.map { resolved ->
+            DryRunJourneyReport(
+              resolvedJourney = resolved,
+              launchYaml = "appId: ${resolved.journey.app}\n---\n- launchApp",
+              segments = emptyList(),
+            )
+          },
+        )
+      })
+      .test("run --dry-run ${dir.absolutePath}")
+
+    assertThat(result.statusCode).isEqualTo(0)
+    assertThat(seen).containsExactly("a.journey.yaml", "b.journey.yaml")
+    assertThat(result.output).contains("# Dry Run: First")
+    assertThat(result.output).contains("# Dry Run: Second")
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+
+@Test
+fun `directory dry run rejects mixed platforms`() {
+  val dir = createTempDirectory("verity-run-dry-mixed").toFile()
+  try {
+    writeJourney(dir, "android.journey.yaml", "Android journey", platform = "android-tv")
+    writeJourney(dir, "ios.journey.yaml", "iOS journey", platform = "ios")
+
+    val result = Verity()
+      .subcommands(dryRunCommand { _, _ -> error("dry-run runner should not be called") })
+      .test("run --dry-run ${dir.absolutePath}")
+
+    assertThat(result.statusCode).isEqualTo(1)
+    assertThat(result.output).contains("Directory suites must use a single platform")
+  } finally {
+    dir.deleteRecursively()
+  }
+}
+```
+
+- [ ] **Step 2: Run targeted tests**
+
+Run: `./gradlew :verity:cli:test --tests me.chrisbanes.verity.cli.RunCommandTest`
+
+Expected: PASS. If the invalid parser message lacks the filename, wrap `loadJourney` failures in `resolveJourney` with `CliktError("Failed to load journey ${file.absolutePath}: ${e.message}")` while rethrowing `CancellationException` first if needed in suspend code.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+git commit -m "test: cover dry-run CLI acceptance cases"
+```
+
+### Task 8: Update Architecture Documentation
+
+**Files:**
+- Modify: `docs/architecture.md`
+
+- [ ] **Step 1: Update CLI mode description**
+
+In `docs/architecture.md`, change line 5 from:
+
+```markdown
+1. **CLI mode** (`verity run`) — Executes journey YAML files against a connected device, using LLMs to generate Maestro flows and evaluate assertions.
+```
+
+to:
+
+```markdown
+1. **CLI mode** (`verity run`) — Executes journey YAML files against a connected device, using LLMs to generate Maestro flows and evaluate assertions. `verity run --dry-run` parses, segments, renders fast-path actions, and generates slow-path Maestro YAML without device access.
+```
+
+- [ ] **Step 2: Add dry-run details near CLI run architecture**
+
+After the segmentation section ending with `Each segment is a natural checkpoint: run actions, evaluate assertion, stop on failure.`, add:
+
+```markdown
+### Dry-Run Planning
+
+`verity run --dry-run` reuses normal journey resolution and segmentation, then switches to a CLI-owned planner instead of `Orchestrator`. The planner renders the launch flow, classifies fast-path action groups with `InteractionMapper`, generates Maestro YAML for slow-path action groups with `NavigatorAgent`, and records assertion descriptions and modes without evaluating them.
+
+Dry-run always prints a Markdown report and writes per-journey artifacts under `<output-path>/dry-run`. It may call the navigator LLM for slow-path YAML, but it does not run device preflight, create `DeviceSession`, execute flows, capture hierarchy, capture screenshots, or evaluate assertions.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "docs: describe run dry-run mode"
+```
+
+### Task 9: Formatting And Full Verification
+
+**Files:**
+- Modify only files changed by Spotless if formatting requires it.
+
+- [ ] **Step 1: Apply formatting**
+
+Run: `./gradlew spotlessApply`
+
+Expected: command succeeds. Inspect any formatting changes before committing.
+
+- [ ] **Step 2: Run full checks**
+
+Run: `./gradlew check`
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Inspect final git diff**
+
+Run: `rtk git status --short`
+
+Expected: only dry-run implementation, tests, docs, and this plan/spec are changed.
+
+Run: `rtk git diff -- docs/superpowers/specs/2026-07-08-dry-run-mode-design.md docs/superpowers/plans/2026-07-08-dry-run-mode.md verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/CliPreflightChecker.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunPlanner.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunRenderer.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriter.kt verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/CliPreflightCheckerTest.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriterTest.kt verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt docs/architecture.md`
+
+Expected: diff contains no unrelated changes and no secrets.
+
+- [ ] **Step 4: Commit final formatting or verification fixes**
+
+If `spotlessApply` changed files or verification required small fixes, commit them:
+
+```bash
+git add verity/cli/src/main/kotlin/me/chrisbanes/verity/cli verity/cli/src/test/kotlin/me/chrisbanes/verity/cli docs/architecture.md docs/superpowers/specs/2026-07-08-dry-run-mode-design.md docs/superpowers/plans/2026-07-08-dry-run-mode.md
+git commit -m "chore: finalize dry-run mode"
+```
+
+If there are no new changes since the previous task commits, skip this commit.

--- a/docs/superpowers/specs/2026-07-08-dry-run-mode-design.md
+++ b/docs/superpowers/specs/2026-07-08-dry-run-mode-design.md
@@ -1,0 +1,118 @@
+# Dry-Run Mode Design
+
+## Goal
+
+Add `verity run --dry-run <journey-or-directory>` so journey authors can validate journey parsing, segmentation, fast-path classification, and generated slow-path Maestro YAML without opening a device session or sending device commands.
+
+Dry-run mode may call the configured navigator LLM when slow-path action YAML is required. It must never run device preflight checks, create a `DeviceSession`, execute Maestro flows, inspect hierarchy, capture screenshots, or evaluate assertions.
+
+## Public Behavior
+
+`verity run --dry-run <path>` accepts the same journey path forms as normal `run`:
+
+- a single `*.journey.yaml` file
+- a directory containing `*.journey.yaml` files
+
+Path resolution, sorted directory discovery, configured journey fallback, platform override, mixed-platform suite rejection, assertion strategy resolution, and journey parser failures should match normal `run` behavior.
+
+Dry-run output is always printed to stdout. It is also written under the resolved output directory, using `--output-path`, `paths.output`, or the existing default `build/verity` in that precedence order.
+
+## CLI Architecture
+
+Add `--dry-run` to `RunCommand` and branch after config loading, output directory validation, path resolution, and journey resolution.
+
+Normal execution remains unchanged. Dry-run execution uses a separate CLI-owned planner and renderer rather than a fake device session or a new mode inside `Orchestrator`. This gives a simple, testable guarantee that dry-run cannot accidentally connect to a device.
+
+The dry-run path should still load project context with the same optional or required context behavior as normal run. It should run provider/model/API-key preflight only before the first slow-path YAML generation. Fast-path-only journeys should not require provider credentials. Dry-run must not run platform device preflight.
+
+## Dry-Run Planner
+
+Introduce a small dry-run model in `:verity:cli`, for example:
+
+```kotlin
+data class DryRunJourneyReport(
+  val file: File,
+  val journey: Journey,
+  val launchYaml: String,
+  val segments: List<DryRunSegmentReport>,
+)
+
+data class DryRunSegmentReport(
+  val index: Int,
+  val actions: List<DryRunActionReport>,
+  val loop: DryRunLoopReport?,
+  val assertion: DryRunAssertionReport?,
+)
+```
+
+The exact type names can vary, but the model should represent the report explicitly rather than constructing console strings during planning.
+
+For each journey, the planner:
+
+1. Adds the launch flow as static YAML: `appId: <app>`, `---`, `- launchApp`.
+2. Segments steps with `JourneySegmenter.segment`.
+3. Classifies action groups with `InteractionMapper.forPlatform(platform)` or `Orchestrator.isFastPath`.
+4. Represents fully mappable action groups as fast-path actions with their mapped interaction type or command description.
+5. Calls `NavigatorAgent.generate(actions, app, platform, context)` for slow-path action groups and stores the generated YAML.
+6. Represents loops with `action`, `until`, and `max`. If the loop action maps to a fast-path interaction, render that mapping. If it does not map, generate and include YAML for one loop action iteration.
+7. Represents assertions by description and mode only. No assertion is evaluated during dry-run.
+
+The planner should create `NavigatorAgent` lazily only when a slow-path action group or slow-path loop action needs YAML. Fast-path-only journeys should not invoke the navigator model.
+
+## Output Format
+
+The stdout report should be readable and stable enough for CLI tests. It should include:
+
+- file path
+- journey name
+- app
+- platform
+- launch YAML
+- segment index
+- fast-path action descriptions
+- slow-path generated YAML blocks
+- loop action, condition, max iteration count, and generated loop YAML when relevant
+- assertion description and assertion mode
+- artifact path written for the journey
+
+Artifact files should be Markdown under:
+
+```text
+<output-path>/dry-run/<journey-file-basename>.md
+```
+
+For a directory suite, each journey writes one artifact. If duplicate basenames are ever possible, the implementation should make names unique deterministically, but non-recursive directory discovery currently makes duplicate basenames impossible within one suite directory.
+
+The artifact content can match stdout per journey. Keeping one rendering function for both stdout sections and files avoids drift.
+
+## Error Handling
+
+Invalid paths, empty directories, mixed-platform suites, invalid platform overrides, and parser failures should behave like normal `run`.
+
+Missing required context should fail before any YAML generation.
+
+Provider, API key, model, or navigator generation failures should fail the dry-run with context that identifies the file and segment being generated. A partial report should not be written as if successful.
+
+Output directory creation and file writes are blocking I/O and should run on `Dispatchers.IO` when called from suspend code.
+
+## Testing
+
+Add CLI-level tests with injected dependencies so no real LLM or device is required.
+
+Coverage should include:
+
+- `run --dry-run <journey>` does not call the normal suite runner or any device-session boundary.
+- invalid journey files still fail with useful parser errors.
+- stdout includes launch YAML, segment indexes, generated slow-path YAML, assertion mode, and fast-path-only segment representation.
+- dry-run writes per-journey Markdown artifacts under the resolved output directory.
+- fast-path-only journeys do not invoke the navigator generator.
+- directory input dry-runs journey files in sorted filename order and writes one artifact per journey.
+- mixed-platform directory input is rejected before dry-run planning, matching normal run.
+
+Use assertk assertions and `kotlinx-coroutines-test` where coroutine tests are needed.
+
+## Documentation
+
+Update `docs/architecture.md` to describe `verity run --dry-run` as a CLI mode that parses, segments, renders fast-path actions, and generates slow-path Maestro YAML without device access.
+
+Update README or CLI help examples only if the implementation adds user-facing command examples elsewhere in the project.

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/CliPreflightChecker.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/CliPreflightChecker.kt
@@ -39,6 +39,7 @@ class CliPreflightChecker(
   suspend fun check(
     request: CliPreflightRequest,
     config: VerityConfig,
+    includeDevicePreflight: Boolean = true,
   ): CliPreflightResult {
     var report = PreflightReport()
     val provider = runCatching { resolveProvider(request.cliProvider, config) }
@@ -61,7 +62,7 @@ class CliPreflightChecker(
       resolveModelSafely(
         provider = it,
         cliModel = request.cliNavigatorModel,
-        configModel = config.navigatorModel,
+        configModel = config.effectiveNavigatorModel,
         defaultModel = it.defaultNavigatorModel,
         role = "navigator",
       ) { modelReport -> report += modelReport }
@@ -70,7 +71,7 @@ class CliPreflightChecker(
       resolveModelSafely(
         provider = it,
         cliModel = request.cliInspectorModel,
-        configModel = config.inspectorModel,
+        configModel = config.effectiveInspectorModel,
         defaultModel = it.defaultInspectorModel,
         role = "inspector",
       ) { modelReport -> report += modelReport }
@@ -130,7 +131,9 @@ class CliPreflightChecker(
     }
 
     report += pathPreflightChecker.requireTempWritable()
-    report += devicePreflightChecker.check(request.platform, request.deviceId)
+    if (includeDevicePreflight) {
+      report += devicePreflightChecker.check(request.platform, request.deviceId)
+    }
 
     return CliPreflightResult(
       report = report,

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/CliPreflightChecker.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/CliPreflightChecker.kt
@@ -40,6 +40,7 @@ class CliPreflightChecker(
     request: CliPreflightRequest,
     config: VerityConfig,
     includeDevicePreflight: Boolean = true,
+    includeInspectorModelPreflight: Boolean = true,
   ): CliPreflightResult {
     var report = PreflightReport()
     val provider = runCatching { resolveProvider(request.cliProvider, config) }
@@ -67,7 +68,7 @@ class CliPreflightChecker(
         role = "navigator",
       ) { modelReport -> report += modelReport }
     }
-    val inspectorModel = provider?.let {
+    val inspectorModel = provider?.takeIf { includeInspectorModelPreflight }?.let {
       resolveModelSafely(
         provider = it,
         cliModel = request.cliInspectorModel,

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriter.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriter.kt
@@ -1,0 +1,50 @@
+package me.chrisbanes.verity.cli
+
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class DryRunArtifactWriter {
+  suspend fun write(
+    outputPath: File,
+    suiteReport: DryRunSuiteReport,
+  ): DryRunSuiteReport = withContext(Dispatchers.IO) {
+    val directory = File(outputPath, "dry-run")
+    if (!directory.mkdirs() && !directory.isDirectory) {
+      throw IllegalStateException("Unable to create dry run artifact directory: ${directory.path}")
+    }
+    val usedNames = mutableSetOf<String>()
+
+    DryRunSuiteReport(
+      journeys =
+      suiteReport.journeys.map { report ->
+        val file = File(directory, uniqueArtifactName(artifactName(report.resolvedJourney.file), usedNames))
+        val reportWithArtifact = report.copy(artifactFile = file)
+        file.writeText(DryRunRenderer.renderJourney(reportWithArtifact))
+        reportWithArtifact
+      },
+    )
+  }
+
+  private fun artifactName(file: File): String {
+    val name = file.name
+    return when {
+      name.endsWith(".journey.yaml") -> name.removeSuffix(".journey.yaml") + ".md"
+      name.endsWith(".yaml") -> name.removeSuffix(".yaml") + ".md"
+      else -> file.nameWithoutExtension + ".md"
+    }
+  }
+
+  private fun uniqueArtifactName(baseName: String, usedNames: MutableSet<String>): String {
+    if (usedNames.add(baseName)) return baseName
+
+    val extension = baseName.substringAfterLast('.', missingDelimiterValue = "")
+    val stem = if (extension.isEmpty()) baseName else baseName.removeSuffix(".$extension")
+    var index = 2
+    while (true) {
+      val candidate = if (extension.isEmpty()) "$stem-$index" else "$stem-$index.$extension"
+      if (usedNames.add(candidate)) return candidate
+      index++
+    }
+  }
+}

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunPlanner.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunPlanner.kt
@@ -1,0 +1,187 @@
+package me.chrisbanes.verity.cli
+
+import com.github.ajalt.clikt.core.CliktError
+import java.io.File
+import kotlin.coroutines.cancellation.CancellationException
+import me.chrisbanes.verity.core.interaction.Interaction
+import me.chrisbanes.verity.core.interaction.InteractionMapper
+import me.chrisbanes.verity.core.journey.JourneySegmenter
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Journey
+import me.chrisbanes.verity.core.model.JourneySegment
+import me.chrisbanes.verity.core.model.Platform
+
+fun interface DryRunNavigator {
+  suspend fun generate(
+    actions: List<String>,
+    appId: String,
+    platform: Platform,
+    context: String,
+  ): String
+}
+
+enum class DryRunExecutionKind {
+  FAST_PATH,
+  SLOW_PATH,
+}
+
+data class DryRunSuiteReport(
+  val journeys: List<DryRunJourneyReport>,
+)
+
+data class DryRunJourneyReport(
+  val resolvedJourney: ResolvedJourney,
+  val launchYaml: String,
+  val segments: List<DryRunSegmentReport>,
+  val artifactFile: File? = null,
+)
+
+data class DryRunSegmentReport(
+  val index: Int,
+  val actions: DryRunActionGroupReport? = null,
+  val loop: DryRunLoopReport? = null,
+  val assertion: DryRunAssertionReport? = null,
+)
+
+data class DryRunActionGroupReport(
+  val instructions: List<String>,
+  val kind: DryRunExecutionKind,
+  val interactions: List<String> = emptyList(),
+  val yaml: String? = null,
+)
+
+data class DryRunLoopReport(
+  val action: String,
+  val until: String,
+  val max: Int,
+  val kind: DryRunExecutionKind,
+  val interaction: String? = null,
+  val yaml: String? = null,
+)
+
+data class DryRunAssertionReport(
+  val description: String,
+  val mode: AssertMode,
+)
+
+class DryRunPlanner(
+  private val navigatorFactory: suspend () -> DryRunNavigator,
+  private val context: String = "",
+) {
+  private var navigator: DryRunNavigator? = null
+
+  suspend fun plan(resolvedJourney: ResolvedJourney): DryRunJourneyReport {
+    val journey = resolvedJourney.journey
+    return DryRunJourneyReport(
+      resolvedJourney = resolvedJourney,
+      launchYaml = launchYaml(journey),
+      segments = JourneySegmenter.segment(journey.steps).map { segment -> planSegment(segment, resolvedJourney) },
+    )
+  }
+
+  private suspend fun planSegment(segment: JourneySegment, resolvedJourney: ResolvedJourney): DryRunSegmentReport {
+    val journey = resolvedJourney.journey
+    return DryRunSegmentReport(
+      index = segment.index,
+      actions = planActions(segment.actions.map { it.instruction }, segment, resolvedJourney),
+      loop = segment.loop?.let { loop ->
+        val mapper = InteractionMapper.forPlatform(journey.platform)
+        val interaction = mapper.map(loop.action)
+        if (interaction != null) {
+          DryRunLoopReport(
+            action = loop.action,
+            until = loop.until,
+            max = loop.max,
+            kind = DryRunExecutionKind.FAST_PATH,
+            interaction = describeInteraction(interaction),
+          )
+        } else {
+          DryRunLoopReport(
+            action = loop.action,
+            until = loop.until,
+            max = loop.max,
+            kind = DryRunExecutionKind.SLOW_PATH,
+            yaml = generateYaml(listOf(loop.action), segment, resolvedJourney),
+          )
+        }
+      },
+      assertion = segment.assertion?.let { DryRunAssertionReport(it.description, it.mode) },
+    )
+  }
+
+  private suspend fun planActions(
+    instructions: List<String>,
+    segment: JourneySegment,
+    resolvedJourney: ResolvedJourney,
+  ): DryRunActionGroupReport? {
+    if (instructions.isEmpty()) return null
+
+    val journey = resolvedJourney.journey
+    val mapper = InteractionMapper.forPlatform(journey.platform)
+    val interactions = instructions.map { mapper.map(it) }
+    return if (interactions.all { it != null }) {
+      DryRunActionGroupReport(
+        instructions = instructions,
+        kind = DryRunExecutionKind.FAST_PATH,
+        interactions = interactions.filterNotNull().map(::describeInteraction),
+      )
+    } else {
+      DryRunActionGroupReport(
+        instructions = instructions,
+        kind = DryRunExecutionKind.SLOW_PATH,
+        yaml = generateYaml(instructions, segment, resolvedJourney),
+      )
+    }
+  }
+
+  private suspend fun generateYaml(
+    instructions: List<String>,
+    segment: JourneySegment,
+    resolvedJourney: ResolvedJourney,
+  ): String {
+    val journey = resolvedJourney.journey
+    return try {
+      navigator().generate(instructions, journey.app, journey.platform, context)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: CliktError) {
+      if (e.message.hasDryRunContext(resolvedJourney, segment)) {
+        throw e
+      }
+      throw generationError(resolvedJourney, segment, e.message)
+    } catch (e: Exception) {
+      throw generationError(resolvedJourney, segment, e.message)
+    }
+  }
+
+  private fun generationError(resolvedJourney: ResolvedJourney, segment: JourneySegment, message: String?): CliktError = CliktError(
+    "Dry-run YAML generation failed for ${resolvedJourney.file.path} segment ${segment.index}: " +
+      (message ?: "unknown error"),
+  )
+
+  private fun String?.hasDryRunContext(resolvedJourney: ResolvedJourney, segment: JourneySegment): Boolean = this?.contains(resolvedJourney.file.path) == true && contains("segment ${segment.index}")
+
+  private suspend fun navigator(): DryRunNavigator = navigator ?: navigatorFactory().also { navigator = it }
+
+  private fun launchYaml(journey: Journey): String = "appId: ${journey.app}\n---\n- launchApp"
+
+  private fun describeInteraction(interaction: Interaction): String = when (interaction) {
+    is Interaction.KeyPress -> "KeyPress(${describeKeyName(interaction.keyName)})"
+    is Interaction.TapOnText -> "TapOnText(${interaction.text})"
+    is Interaction.TapOnId -> "TapOnId(${interaction.resourceId})"
+    is Interaction.Scroll -> "Scroll(${interaction.direction})"
+    is Interaction.Swipe -> "Swipe(${interaction.direction})"
+    Interaction.LongPressOnFocused -> "LongPressOnFocused"
+    is Interaction.LongPressOnText -> "LongPressOnText(${interaction.text})"
+    Interaction.PullToRefresh -> "PullToRefresh"
+  }
+
+  private fun describeKeyName(keyName: String): String = when (keyName) {
+    "Remote Dpad Down" -> "DPAD_DOWN"
+    "Remote Dpad Up" -> "DPAD_UP"
+    "Remote Dpad Left" -> "DPAD_LEFT"
+    "Remote Dpad Right" -> "DPAD_RIGHT"
+    "Remote Dpad Center" -> "DPAD_CENTER"
+    else -> keyName
+  }
+}

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunRenderer.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/DryRunRenderer.kt
@@ -1,0 +1,64 @@
+package me.chrisbanes.verity.cli
+
+object DryRunRenderer {
+  fun renderJourney(report: DryRunJourneyReport): String = buildString {
+    val resolved = report.resolvedJourney
+    val journey = resolved.journey
+    appendLine("# Dry Run: ${journey.name}")
+    appendLine()
+    appendLine("File: ${resolved.file.path}")
+    appendLine("App: ${journey.app}")
+    appendLine("Platform: ${journey.platform}")
+    report.artifactFile?.let { appendLine("Artifact: ${it.path}") }
+    appendLine()
+    appendLine("## Launch Flow")
+    appendYaml(report.launchYaml)
+    report.segments.forEach { segment ->
+      appendLine()
+      appendLine("## Segment ${segment.index}")
+      segment.actions?.let { actions ->
+        appendLine()
+        appendLine("Actions:")
+        actions.instructions.forEach { appendLine("- $it") }
+        appendLine("Kind: ${actions.kind}")
+        if (actions.interactions.isNotEmpty()) {
+          appendLine("Interactions:")
+          actions.interactions.forEach { appendLine("- $it") }
+        }
+        actions.yaml?.let {
+          appendLine("Generated YAML:")
+          appendYaml(it)
+        }
+      }
+      segment.loop?.let { loop ->
+        appendLine()
+        appendLine("Loop: ${loop.action} until ${loop.until}, max ${loop.max}")
+        appendLine("Kind: ${loop.kind}")
+        loop.interaction?.let { appendLine("Interaction: $it") }
+        loop.yaml?.let {
+          appendLine("Generated Loop YAML:")
+          appendYaml(it)
+        }
+      }
+      segment.assertion?.let { assertion ->
+        appendLine()
+        appendLine("Assertion: [${assertion.mode}] ${assertion.description}")
+      }
+    }
+  }.trimEnd()
+
+  fun renderSuite(report: DryRunSuiteReport): String = report.journeys
+    .joinToString(separator = "\n\n---\n\n") { renderJourney(it) }
+
+  private fun StringBuilder.appendYaml(yaml: String) {
+    val fence = codeFenceFor(yaml)
+    appendLine("${fence}yaml")
+    appendLine(yaml.trimEnd())
+    appendLine(fence)
+  }
+
+  private fun codeFenceFor(yaml: String): String {
+    val longestRun = "`+".toRegex().findAll(yaml).maxOfOrNull { it.value.length } ?: 0
+    return "`".repeat(maxOf(3, longestRun + 1))
+  }
+}

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -241,6 +241,7 @@ class RunCommand(
       ),
       config = config,
       includeDevicePreflight = false,
+      includeInspectorModelPreflight = false,
     )
     if (!preflight.report.passed) {
       throw CliktError(preflight.report.renderPlainText())

--- a/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
+++ b/verity/cli/src/main/kotlin/me/chrisbanes/verity/cli/RunCommand.kt
@@ -9,10 +9,13 @@ import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
 import me.chrisbanes.verity.agent.InspectorAgent
 import me.chrisbanes.verity.agent.JourneyResult
 import me.chrisbanes.verity.agent.NavigatorAgent
@@ -49,10 +52,15 @@ class RunCommand(
   private val loadJourney: (File, AssertionStrategy) -> Journey = JourneyLoader::fromFile,
   private val listJourneyFiles: (File) -> List<File> = JourneyLoader::listJourneyFiles,
   private val suiteRunner: (suspend (List<ResolvedJourney>) -> SuiteRunResult)? = null,
+  private val dryRunSuiteRunner: (suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport)? = null,
 ) : CliktCommand(name = "run") {
   override fun help(context: Context): String = "Execute a journey file against a connected device"
 
   private val journeyPath by argument("journey", help = "Path to .journey.yaml file").optional()
+  private val dryRun by option(
+    "--dry-run",
+    help = "Validate journeys and render generated Maestro YAML without device access",
+  ).flag()
 
   private fun resolveJourneys(
     path: File,
@@ -84,7 +92,11 @@ class RunCommand(
     assertionStrategy: AssertionStrategy,
     platformOverride: Platform?,
   ): ResolvedJourney {
-    val journey = loadJourney(file, assertionStrategy)
+    val journey = try {
+      loadJourney(file, assertionStrategy)
+    } catch (e: SerializationException) {
+      throw CliktError("Failed to load journey ${file.absolutePath}: ${e.message}")
+    }
     return ResolvedJourney(
       file = file,
       journey = applyResolvedPlatform(journey, platformOverride),
@@ -107,10 +119,15 @@ class RunCommand(
     val parent = currentContext.parent?.command as Verity
 
     val config = VerityConfig.loadOrDefault(File("verity/config.yaml"))
-    val resolved = ResolvedProjectConfig.resolve(
-      config = config,
-      cli = parent.projectCliOptions(),
-    )
+    val cliOptions = parent.projectCliOptions()
+    val resolved = if (dryRun) {
+      resolveDryRunProjectConfig(config, cliOptions)
+    } else {
+      ResolvedProjectConfig.resolve(
+        config = config,
+        cli = cliOptions,
+      )
+    }
     validateOutputDirectory(resolved.outputPath)
 
     val path = try {
@@ -123,6 +140,19 @@ class RunCommand(
       assertionStrategy = resolved.assertionStrategy,
       platformOverride = resolved.platform,
     )
+
+    if (dryRun) {
+      val dryRunReport = dryRunSuiteRunner?.invoke(journeys, resolved.outputPath)
+        ?: runDryRun(
+          parent = parent,
+          config = config,
+          resolved = resolved,
+          path = path,
+          journeys = journeys,
+        )
+      echo(DryRunRenderer.renderSuite(dryRunReport))
+      return@runBlocking
+    }
 
     val suiteResult = suiteRunner?.invoke(journeys)
       ?: runSuiteWithDevice(
@@ -137,6 +167,100 @@ class RunCommand(
 
     if (!suiteResult.passed) {
       throw CliktError("Journey suite failed")
+    }
+  }
+
+  private fun resolveDryRunProjectConfig(
+    config: VerityConfig,
+    cli: ProjectCliOptions,
+  ): ResolvedProjectConfig = ResolvedProjectConfig.resolve(
+    config = config.copy(
+      llm = config.llm?.copy(
+        provider = null,
+        navigatorModel = null,
+        inspectorModel = null,
+      ),
+      provider = null,
+      navigatorModel = null,
+      inspectorModel = null,
+    ),
+    cli = cli.copy(
+      provider = "ollama",
+      navigatorModel = null,
+      inspectorModel = null,
+    ),
+  )
+
+  private suspend fun runDryRun(
+    parent: Verity,
+    config: VerityConfig,
+    resolved: ResolvedProjectConfig,
+    path: File,
+    journeys: List<ResolvedJourney>,
+  ): DryRunSuiteReport {
+    val contextDir = resolved.contextPath
+    val requireContext = resolveRequiredContext(parent.requireContext, config)
+    val projectContext = try {
+      withContext(Dispatchers.IO) {
+        ContextLoader.loadProject(directory = contextDir, required = requireContext)
+      }
+    } catch (e: ContextValidationException) {
+      throw CliktError(e.message ?: "Project context validation failed")
+    }
+    projectContext.describeForCli(contextDir, requireContext).forEach { echo(it) }
+
+    var dryRunNavigator: DryRunNavigator? = null
+    val planner = DryRunPlanner(
+      context = projectContext.text,
+      navigatorFactory = {
+        dryRunNavigator ?: createDryRunNavigator(parent, config, resolved, path, journeys.first().journey.platform)
+          .also { dryRunNavigator = it }
+      },
+    )
+    val suiteReport = DryRunSuiteReport(journeys.map { resolvedJourney -> planner.plan(resolvedJourney) })
+    return DryRunArtifactWriter().write(resolved.outputPath, suiteReport)
+  }
+
+  private suspend fun createDryRunNavigator(
+    parent: Verity,
+    config: VerityConfig,
+    resolved: ResolvedProjectConfig,
+    path: File,
+    platform: Platform,
+  ): DryRunNavigator {
+    val preflight = CliPreflightChecker().check(
+      request = CliPreflightRequest(
+        cliProvider = parent.provider,
+        cliNavigatorModel = parent.navigatorModel,
+        cliInspectorModel = parent.inspectorModel,
+        apiKey = parent.apiKey,
+        journeyPath = path.path,
+        contextPath = null,
+        platform = platform,
+        deviceId = resolved.deviceId,
+      ),
+      config = config,
+      includeDevicePreflight = false,
+    )
+    if (!preflight.report.passed) {
+      throw CliktError(preflight.report.renderPlainText())
+    }
+
+    val provider = checkNotNull(preflight.provider)
+    val navigatorModel = checkNotNull(preflight.navigatorModel)
+    val executor = MultiLLMPromptExecutor(provider.createClient(preflight.apiKey.orEmpty()))
+    val navigatorAgent = NavigatorAgent(
+      bundledContext = if (parent.noBundledContext) "" else ContextLoader.loadBundled(),
+      agentFactory = { systemPrompt ->
+        AIAgent(
+          promptExecutor = executor,
+          llmModel = navigatorModel,
+          systemPrompt = systemPrompt,
+        )
+      },
+    )
+    return DryRunNavigator { actions, appId, targetPlatform, context ->
+      navigatorAgent.generate(actions, appId, targetPlatform, context)
     }
   }
 

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/CliPreflightCheckerTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/CliPreflightCheckerTest.kt
@@ -190,6 +190,35 @@ class CliPreflightCheckerTest {
   }
 
   @Test
+  fun `can skip inspector model validation for dry run navigator preflight`() = runTest {
+    val journey = Files.createTempFile("journey-", ".journey.yaml")
+    val checker = CliPreflightChecker(
+      environment = { name -> if (name == "ANTHROPIC_API_KEY") "secret" else null },
+      devicePreflightChecker = DevicePreflightChecker { _, _ -> PreflightReport() },
+    )
+
+    val result = checker.check(
+      request = CliPreflightRequest(
+        cliProvider = "anthropic",
+        cliNavigatorModel = "claude-haiku-4-5",
+        cliInspectorModel = "definitely-not-real",
+        apiKey = null,
+        journeyPath = journey.toString(),
+        contextPath = null,
+        platform = Platform.ANDROID_TV,
+        deviceId = null,
+      ),
+      config = VerityConfig(),
+      includeDevicePreflight = false,
+      includeInspectorModelPreflight = false,
+    )
+
+    assertThat(result.report.passed).isTrue()
+    assertThat(result.navigatorModel?.id).isEqualTo("claude-haiku-4-5")
+    assertThat(result.inspectorModel).isEqualTo(null)
+  }
+
+  @Test
   fun `plain text render contains remediation for cli error`() = runTest {
     val checker = CliPreflightChecker(
       environment = { null },

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/CliPreflightCheckerTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/CliPreflightCheckerTest.kt
@@ -95,6 +95,38 @@ class CliPreflightCheckerTest {
   }
 
   @Test
+  fun `reports unknown nested llm navigator model without throwing`() = runTest {
+    val journey = Files.createTempFile("journey-", ".journey.yaml")
+    val checker = CliPreflightChecker(
+      devicePreflightChecker = DevicePreflightChecker { _, _ -> PreflightReport() },
+    )
+
+    val result = checker.check(
+      request = CliPreflightRequest(
+        cliProvider = null,
+        cliNavigatorModel = null,
+        cliInspectorModel = null,
+        apiKey = null,
+        journeyPath = journey.toString(),
+        contextPath = null,
+        platform = Platform.ANDROID_TV,
+        deviceId = null,
+      ),
+      config = VerityConfig(
+        llm = VerityLlmConfig(
+          provider = "ollama",
+          navigatorModel = "definitely-not-real",
+        ),
+      ),
+      includeDevicePreflight = false,
+    )
+
+    assertThat(result.report.passed).isFalse()
+    assertThat(result.report.issues.single().code).isEqualTo(PreflightCodes.PROVIDER_MODEL_UNKNOWN)
+    assertThat(result.report.issues.single().message).contains("Unknown model 'definitely-not-real'")
+  }
+
+  @Test
   fun `runs device preflight for selected platform`() = runTest {
     val journey = Files.createTempFile("journey-", ".journey.yaml")
     var receivedPlatform: Platform? = null
@@ -124,6 +156,37 @@ class CliPreflightCheckerTest {
 
     assertThat(receivedPlatform).isEqualTo(Platform.IOS)
     assertThat(receivedDevice).isEqualTo("sim-1")
+  }
+
+  @Test
+  fun `can skip device preflight for dry run`() = runTest {
+    val journey = Files.createTempFile("journey-", ".journey.yaml")
+    var devicePreflightCalls = 0
+    val checker = CliPreflightChecker(
+      environment = { name -> if (name == "ANTHROPIC_API_KEY") "secret" else null },
+      devicePreflightChecker = DevicePreflightChecker { _, _ ->
+        devicePreflightCalls += 1
+        PreflightReport()
+      },
+    )
+
+    val result = checker.check(
+      request = CliPreflightRequest(
+        cliProvider = "anthropic",
+        cliNavigatorModel = null,
+        cliInspectorModel = null,
+        apiKey = null,
+        journeyPath = journey.toString(),
+        contextPath = null,
+        platform = Platform.ANDROID_TV,
+        deviceId = null,
+      ),
+      config = VerityConfig(),
+      includeDevicePreflight = false,
+    )
+
+    assertThat(result.report.passed).isTrue()
+    assertThat(devicePreflightCalls).isEqualTo(0)
   }
 
   @Test

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriterTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunArtifactWriterTest.kt
@@ -1,0 +1,103 @@
+package me.chrisbanes.verity.cli
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isTrue
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import me.chrisbanes.verity.core.model.Journey
+import me.chrisbanes.verity.core.model.Platform
+
+class DryRunArtifactWriterTest {
+  @Test
+  fun `writes one markdown artifact per journey under dry run directory`() = runTest {
+    val output = createTempDirectory("verity-dry-run-output").toFile()
+    try {
+      val journey =
+        Journey(
+          name = "Artifact journey",
+          app = "com.example.app",
+          platform = Platform.ANDROID_TV,
+          steps = emptyList(),
+        )
+      val report =
+        DryRunJourneyReport(
+          resolvedJourney = ResolvedJourney(File("artifact.journey.yaml"), journey),
+          launchYaml = "appId: com.example.app\n---\n- launchApp",
+          segments = emptyList(),
+        )
+
+      val suite = DryRunArtifactWriter().write(output, DryRunSuiteReport(listOf(report)))
+
+      val written = suite.journeys.single().artifactFile
+      assertThat(written?.parentFile?.name).isEqualTo("dry-run")
+      assertThat(written?.name).isEqualTo("artifact.md")
+      assertThat(written?.readText().orEmpty()).contains("# Dry Run: Artifact journey")
+      assertThat(written?.readText().orEmpty()).contains("Artifact: ${written?.path}")
+      assertThat(suite.journeys.single().resolvedJourney).isEqualTo(report.resolvedJourney)
+    } finally {
+      output.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `writes distinct artifacts for journeys with duplicate basenames`() = runTest {
+    val output = createTempDirectory("verity-dry-run-output").toFile()
+    try {
+      val firstReport = reportFor("First duplicate", File("one/duplicate.journey.yaml"))
+      val secondReport = reportFor("Second duplicate", File("two/duplicate.journey.yaml"))
+
+      val suite = DryRunArtifactWriter().write(output, DryRunSuiteReport(listOf(firstReport, secondReport)))
+
+      val firstFile = suite.journeys[0].artifactFile
+      val secondFile = suite.journeys[1].artifactFile
+      assertThat(firstFile?.name).isEqualTo("duplicate.md")
+      assertThat(secondFile?.name).isEqualTo("duplicate-2.md")
+      assertThat(firstFile?.path).isNotEqualTo(secondFile?.path)
+      assertThat(firstFile?.isFile == true).isTrue()
+      assertThat(secondFile?.isFile == true).isTrue()
+    } finally {
+      output.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `fails clearly when dry run directory cannot be created`() = runTest {
+    val output = createTempDirectory("verity-dry-run-output").toFile()
+    try {
+      val dryRunPath = File(output, "dry-run")
+      dryRunPath.writeText("not a directory")
+
+      val error = assertFailsWith<IllegalStateException> {
+        DryRunArtifactWriter().write(
+          output,
+          DryRunSuiteReport(listOf(reportFor("Blocked artifact", File("blocked.journey.yaml")))),
+        )
+      }
+
+      assertThat(error.message.orEmpty()).contains(dryRunPath.path)
+    } finally {
+      output.deleteRecursively()
+    }
+  }
+
+  private fun reportFor(name: String, file: File): DryRunJourneyReport {
+    val journey =
+      Journey(
+        name = name,
+        app = "com.example.app",
+        platform = Platform.ANDROID_TV,
+        steps = emptyList(),
+      )
+    return DryRunJourneyReport(
+      resolvedJourney = ResolvedJourney(file, journey),
+      launchYaml = "appId: com.example.app\n---\n- launchApp",
+      segments = emptyList(),
+    )
+  }
+}

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/DryRunPlannerTest.kt
@@ -1,0 +1,303 @@
+package me.chrisbanes.verity.cli
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.messageContains
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import me.chrisbanes.verity.core.model.AssertMode
+import me.chrisbanes.verity.core.model.Journey
+import me.chrisbanes.verity.core.model.JourneyStep
+import me.chrisbanes.verity.core.model.Platform
+
+class DryRunPlannerTest {
+  @Test
+  fun `fast path actions are represented without invoking navigator`() = runTest {
+    var navigatorCalls = 0
+    val planner = DryRunPlanner(
+      navigatorFactory = {
+        navigatorCalls += 1
+        DryRunNavigator { _, _, _, _ -> error("navigator should not be called") }
+      },
+    )
+    val journey = Journey(
+      name = "Fast journey",
+      app = "com.example.app",
+      platform = Platform.ANDROID_TV,
+      steps = listOf(
+        JourneyStep.Action("press d-pad down"),
+        JourneyStep.Action("press select"),
+        JourneyStep.Assert("Home", AssertMode.VISIBLE),
+      ),
+    )
+
+    val report = planner.plan(resolvedJourney(journey))
+
+    assertThat(navigatorCalls).isEqualTo(0)
+    assertThat(report.launchYaml).isEqualTo("appId: com.example.app\n---\n- launchApp")
+    assertThat(report.segments).transform { it.size }.isEqualTo(1)
+    val segment = report.segments.single()
+    assertThat(segment.index).isEqualTo(0)
+    assertThat(segment.actions?.kind).isEqualTo(DryRunExecutionKind.FAST_PATH)
+    assertThat(segment.actions?.instructions.orEmpty()).containsExactly("press d-pad down", "press select")
+    assertThat(segment.actions?.interactions.orEmpty()).contains("KeyPress(DPAD_DOWN)")
+    assertThat(segment.actions?.yaml).isNull()
+    assertThat(segment.assertion?.description).isEqualTo("Home")
+    assertThat(segment.assertion?.mode).isEqualTo(AssertMode.VISIBLE)
+  }
+
+  @Test
+  fun `slow path actions include generated yaml`() = runTest {
+    val planner = DryRunPlanner(
+      navigatorFactory = {
+        DryRunNavigator { actions, appId, platform, context ->
+          assertThat(actions).containsExactly("complete onboarding wizard")
+          assertThat(appId).isEqualTo("com.example.app")
+          assertThat(platform).isEqualTo(Platform.ANDROID_MOBILE)
+          assertThat(context).isEqualTo("project context")
+          "appId: com.example.app\n---\n- tapOn: \"Settings\""
+        }
+      },
+      context = "project context",
+    )
+    val journey = Journey(
+      name = "Slow journey",
+      app = "com.example.app",
+      platform = Platform.ANDROID_MOBILE,
+      steps = listOf(JourneyStep.Action("complete onboarding wizard")),
+    )
+
+    val segment = planner.plan(resolvedJourney(journey)).segments.single()
+
+    assertThat(segment.actions?.kind).isEqualTo(DryRunExecutionKind.SLOW_PATH)
+    assertThat(segment.actions?.yaml).isEqualTo("appId: com.example.app\n---\n- tapOn: \"Settings\"")
+  }
+
+  @Test
+  fun `slow path action generation failure includes journey file and segment`() = runTest {
+    val planner = DryRunPlanner(
+      navigatorFactory = {
+        DryRunNavigator { _, _, _, _ -> error("navigator exploded") }
+      },
+    )
+    val journey = Journey(
+      name = "Slow journey",
+      app = "com.example.app",
+      platform = Platform.ANDROID_MOBILE,
+      steps = listOf(JourneyStep.Action("complete onboarding wizard")),
+    )
+
+    val failure = assertFailure {
+      planner.plan(resolvedJourney(journey))
+    }
+    failure.messageContains("Slow journey.journey.yaml")
+    failure.messageContains("segment 0")
+    failure.messageContains("navigator exploded")
+  }
+
+  @Test
+  fun `loop reports fast path mapping when action maps`() = runTest {
+    val planner = DryRunPlanner(
+      navigatorFactory = { DryRunNavigator { _, _, _, _ -> error("navigator should not be called") } },
+    )
+    val journey = Journey(
+      name = "Loop journey",
+      app = "com.example.app",
+      platform = Platform.ANDROID_TV,
+      steps = listOf(JourneyStep.Loop(action = "press d-pad down", until = "Settings", max = 3)),
+    )
+
+    val loop = planner.plan(resolvedJourney(journey)).segments.single().loop
+
+    assertThat(loop?.kind).isEqualTo(DryRunExecutionKind.FAST_PATH)
+    assertThat(loop?.action).isEqualTo("press d-pad down")
+    assertThat(loop?.until).isEqualTo("Settings")
+    assertThat(loop?.max).isEqualTo(3)
+    assertThat(loop?.interaction).isEqualTo("KeyPress(DPAD_DOWN)")
+    assertThat(loop?.yaml).isNull()
+  }
+
+  @Test
+  fun `loop reports generated yaml when action does not map`() = runTest {
+    val planner = DryRunPlanner(
+      navigatorFactory = {
+        DryRunNavigator { actions, appId, platform, context ->
+          assertThat(actions).containsExactly("navigate to settings page")
+          assertThat(appId).isEqualTo("com.example.app")
+          assertThat(platform).isEqualTo(Platform.ANDROID_MOBILE)
+          assertThat(context).isEqualTo("loop context")
+          "appId: com.example.app\n---\n- tapOn: \"Settings\""
+        }
+      },
+      context = "loop context",
+    )
+    val journey = Journey(
+      name = "Slow loop journey",
+      app = "com.example.app",
+      platform = Platform.ANDROID_MOBILE,
+      steps = listOf(JourneyStep.Loop(action = "navigate to settings page", until = "Settings", max = 2)),
+    )
+
+    val loop = planner.plan(resolvedJourney(journey)).segments.single().loop
+
+    assertThat(loop?.kind).isEqualTo(DryRunExecutionKind.SLOW_PATH)
+    assertThat(loop?.yaml).isEqualTo("appId: com.example.app\n---\n- tapOn: \"Settings\"")
+  }
+
+  @Test
+  fun `slow path loop generation failure includes journey file and segment`() = runTest {
+    val planner = DryRunPlanner(
+      navigatorFactory = {
+        DryRunNavigator { _, _, _, _ -> error("loop navigator exploded") }
+      },
+    )
+    val journey = Journey(
+      name = "Slow loop journey",
+      app = "com.example.app",
+      platform = Platform.ANDROID_MOBILE,
+      steps = listOf(JourneyStep.Loop(action = "navigate to settings page", until = "Settings", max = 2)),
+    )
+
+    val failure = assertFailure {
+      planner.plan(resolvedJourney(journey))
+    }
+    failure.messageContains("Slow loop journey.journey.yaml")
+    failure.messageContains("segment 0")
+    failure.messageContains("loop navigator exploded")
+  }
+
+  @Test
+  fun `renderer includes launch yaml segments fast path slow path loops and assertions`() = runTest {
+    val report = DryRunJourneyReport(
+      resolvedJourney = resolvedJourney(
+        Journey(
+          name = "Rendered journey",
+          app = "com.example.app",
+          platform = Platform.ANDROID_MOBILE,
+          steps = emptyList(),
+        ),
+      ),
+      launchYaml = "appId: com.example.app\n---\n- launchApp",
+      segments = listOf(
+        DryRunSegmentReport(
+          index = 0,
+          actions = DryRunActionGroupReport(
+            instructions = listOf("tap Settings"),
+            kind = DryRunExecutionKind.FAST_PATH,
+            interactions = listOf("TapOnText(Settings)"),
+          ),
+          assertion = DryRunAssertionReport("Settings", AssertMode.VISIBLE),
+        ),
+        DryRunSegmentReport(
+          index = 1,
+          actions = DryRunActionGroupReport(
+            instructions = listOf("open account details"),
+            kind = DryRunExecutionKind.SLOW_PATH,
+            yaml = "appId: com.example.app\n---\n- tapOn: \"Account\"",
+          ),
+          loop = DryRunLoopReport(
+            action = "navigate to logout",
+            until = "Logout",
+            max = 2,
+            kind = DryRunExecutionKind.SLOW_PATH,
+            yaml = "appId: com.example.app\n---\n- scroll",
+          ),
+        ),
+      ),
+    )
+
+    val markdown = DryRunRenderer.renderJourney(report)
+
+    assertThat(markdown).isEqualTo(
+      """
+      # Dry Run: Rendered journey
+
+      File: Rendered journey.journey.yaml
+      App: com.example.app
+      Platform: ANDROID_MOBILE
+
+      ## Launch Flow
+      ```yaml
+      appId: com.example.app
+      ---
+      - launchApp
+      ```
+
+      ## Segment 0
+
+      Actions:
+      - tap Settings
+      Kind: FAST_PATH
+      Interactions:
+      - TapOnText(Settings)
+
+      Assertion: [VISIBLE] Settings
+
+      ## Segment 1
+
+      Actions:
+      - open account details
+      Kind: SLOW_PATH
+      Generated YAML:
+      ```yaml
+      appId: com.example.app
+      ---
+      - tapOn: "Account"
+      ```
+
+      Loop: navigate to logout until Logout, max 2
+      Kind: SLOW_PATH
+      Generated Loop YAML:
+      ```yaml
+      appId: com.example.app
+      ---
+      - scroll
+      ```
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun `renderer uses longer yaml fence when yaml contains backticks`() = runTest {
+    val report = DryRunJourneyReport(
+      resolvedJourney = resolvedJourney(
+        Journey(
+          name = "Backtick journey",
+          app = "com.example.app",
+          platform = Platform.ANDROID_MOBILE,
+          steps = emptyList(),
+        ),
+      ),
+      launchYaml = "appId: com.example.app\n---\n- inputText: ```code```",
+      segments = emptyList(),
+    )
+
+    val markdown = DryRunRenderer.renderJourney(report)
+
+    assertThat(markdown).isEqualTo(
+      """
+      # Dry Run: Backtick journey
+
+      File: Backtick journey.journey.yaml
+      App: com.example.app
+      Platform: ANDROID_MOBILE
+
+      ## Launch Flow
+      ````yaml
+      appId: com.example.app
+      ---
+      - inputText: ```code```
+      ````
+      """.trimIndent(),
+    )
+  }
+
+  private fun resolvedJourney(journey: Journey): ResolvedJourney = ResolvedJourney(
+    file = java.io.File("${journey.name}.journey.yaml"),
+    journey = journey,
+  )
+}

--- a/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
+++ b/verity/cli/src/test/kotlin/me/chrisbanes/verity/cli/RunCommandTest.kt
@@ -3,6 +3,8 @@ package me.chrisbanes.verity.cli
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.containsExactly
+import assertk.assertions.doesNotContain
+import assertk.assertions.exists
 import assertk.assertions.isEqualTo
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.testing.test
@@ -190,9 +192,253 @@ class RunCommandTest {
     }
   }
 
+  @Test
+  fun `dry run uses dry-run runner and does not call normal suite runner`() {
+    val dir = createTempDirectory("verity-run-dry").toFile()
+    try {
+      val output = File(dir, "out")
+      val file = writeJourney(dir, "dry.journey.yaml", "Dry journey")
+      var dryRunCalled = false
+      val command = RunCommand(
+        suiteRunner = { error("normal suite runner should not be called") },
+        dryRunSuiteRunner = { journeys, outputPath ->
+          dryRunCalled = true
+          assertThat(journeys.map { it.file.name }).containsExactly("dry.journey.yaml")
+          assertThat(outputPath).isEqualTo(output)
+          DryRunSuiteReport(
+            journeys = listOf(
+              DryRunJourneyReport(
+                resolvedJourney = journeys.single(),
+                launchYaml = "appId: com.example.app\n---\n- launchApp",
+                segments = emptyList(),
+                artifactFile = File(output, "dry-run/dry.md"),
+              ),
+            ),
+          )
+        },
+      )
+
+      val result = Verity()
+        .subcommands(command)
+        .test(listOf("--output-path", output.absolutePath, "run", "--dry-run", file.absolutePath))
+
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(dryRunCalled).isEqualTo(true)
+      assertThat(result.output).contains("# Dry Run: Dry journey")
+      assertThat(result.output).contains("Artifact: ${File(output, "dry-run/dry.md").path}")
+      assertThat(result.output).doesNotContain("Suite result:")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `dry run invalid journey fails before dry-run runner`() {
+    val dir = createTempDirectory("verity-run-dry-invalid").toFile()
+    try {
+      val file = File(dir, "invalid.journey.yaml")
+      file.writeText("name: Invalid\nsteps: not-a-list")
+
+      val result = Verity()
+        .subcommands(dryRunCommand { _, _ -> error("dry-run runner should not be called") })
+        .test("run --dry-run ${file.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("invalid.journey.yaml")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `directory dry run resolves files in sorted order`() {
+    val dir = createTempDirectory("verity-run-dry-directory").toFile()
+    try {
+      writeJourney(dir, "b.journey.yaml", "Second")
+      writeJourney(dir, "a.journey.yaml", "First")
+      val seen = mutableListOf<String>()
+
+      val result = Verity()
+        .subcommands(
+          dryRunCommand { journeys, _ ->
+            seen += journeys.map { it.file.name }
+            DryRunSuiteReport(
+              journeys.map { resolved ->
+                DryRunJourneyReport(
+                  resolvedJourney = resolved,
+                  launchYaml = "appId: ${resolved.journey.app}\n---\n- launchApp",
+                  segments = emptyList(),
+                )
+              },
+            )
+          },
+        )
+        .test("run --dry-run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(seen).containsExactly("a.journey.yaml", "b.journey.yaml")
+      assertThat(result.output).contains("# Dry Run: First")
+      assertThat(result.output).contains("# Dry Run: Second")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `directory dry run rejects mixed platforms`() {
+    val dir = createTempDirectory("verity-run-dry-mixed").toFile()
+    try {
+      writeJourney(dir, "android.journey.yaml", "Android journey", platform = "android-tv")
+      writeJourney(dir, "ios.journey.yaml", "iOS journey", platform = "ios")
+
+      val result = Verity()
+        .subcommands(dryRunCommand { _, _ -> error("dry-run runner should not be called") })
+        .test("run --dry-run ${dir.absolutePath}")
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("Directory suites must use a single platform")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `dry run writes artifacts with production dry-run runner`() {
+    val dir = createTempDirectory("verity-run-dry-artifact").toFile()
+    try {
+      val output = File(dir, "out")
+      val file = writeJourneyWithSteps(
+        dir = dir,
+        name = "fast.journey.yaml",
+        journeyName = "Fast dry journey",
+        steps = listOf("press d-pad down", "[?] Home"),
+      )
+
+      val result = Verity()
+        .subcommands(RunCommand())
+        .test(listOf("--output-path", output.absolutePath, "run", "--dry-run", file.absolutePath))
+
+      val artifact = File(output, "dry-run/fast.md")
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(artifact).exists()
+      assertThat(artifact.readText()).contains("# Dry Run: Fast dry journey")
+      assertThat(result.output).contains("KeyPress(DPAD_DOWN)")
+      assertThat(result.output).contains("Assertion: [VISIBLE] Home")
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `fast path dry run does not require valid provider config`() {
+    val dir = createTempDirectory("verity-run-dry-invalid-provider").toFile()
+    val configFile = File("verity/config.yaml")
+    val originalConfig = configFile.takeIf { it.exists() }?.readText()
+    try {
+      configFile.parentFile.mkdirs()
+      configFile.writeText("provider: definitely-not-real")
+      val output = File(dir, "out")
+      val file = writeJourneyWithSteps(
+        dir = dir,
+        name = "fast-invalid-provider.journey.yaml",
+        journeyName = "Fast invalid provider dry run",
+        steps = listOf("press d-pad down", "[?] Home"),
+      )
+
+      val result = Verity()
+        .subcommands(RunCommand())
+        .test(listOf("--output-path", output.absolutePath, "run", "--dry-run", file.absolutePath))
+
+      assertThat(result.statusCode).isEqualTo(0)
+      assertThat(result.output).contains("KeyPress(DPAD_DOWN)")
+    } finally {
+      if (originalConfig == null) {
+        configFile.delete()
+      } else {
+        configFile.writeText(originalConfig)
+      }
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `slow path dry run validates provider when navigator is needed`() {
+    val dir = createTempDirectory("verity-run-dry-slow-invalid-provider").toFile()
+    val configFile = File("verity/config.yaml")
+    val originalConfig = configFile.takeIf { it.exists() }?.readText()
+    try {
+      configFile.parentFile.mkdirs()
+      configFile.writeText("provider: definitely-not-real")
+      val output = File(dir, "out")
+      val file = writeJourneyWithSteps(
+        dir = dir,
+        name = "slow-invalid-provider.journey.yaml",
+        journeyName = "Slow invalid provider dry run",
+        steps = listOf("open the profile drawer", "[?] Home"),
+      )
+
+      val result = Verity()
+        .subcommands(RunCommand())
+        .test(listOf("--output-path", output.absolutePath, "run", "--dry-run", file.absolutePath))
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("Unknown provider")
+      assertThat(result.output).doesNotContain("KeyPress(DPAD_DOWN)")
+    } finally {
+      if (originalConfig == null) {
+        configFile.delete()
+      } else {
+        configFile.writeText(originalConfig)
+      }
+      dir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `slow path dry run validates nested llm navigator model when navigator is needed`() {
+    val dir = createTempDirectory("verity-run-dry-slow-invalid-nested-model").toFile()
+    val configFile = File("verity/config.yaml")
+    val originalConfig = configFile.takeIf { it.exists() }?.readText()
+    try {
+      configFile.parentFile.mkdirs()
+      configFile.writeText(
+        """
+        llm:
+          provider: ollama
+          navigator-model: definitely-not-real
+        """.trimIndent(),
+      )
+      val output = File(dir, "out")
+      val file = writeJourneyWithSteps(
+        dir = dir,
+        name = "slow-invalid-nested-model.journey.yaml",
+        journeyName = "Slow invalid nested model dry run",
+        steps = listOf("open the profile drawer", "[?] Home"),
+      )
+
+      val result = Verity()
+        .subcommands(RunCommand())
+        .test(listOf("--output-path", output.absolutePath, "run", "--dry-run", file.absolutePath))
+
+      assertThat(result.statusCode).isEqualTo(1)
+      assertThat(result.output).contains("Unknown model 'definitely-not-real'")
+    } finally {
+      if (originalConfig == null) {
+        configFile.delete()
+      } else {
+        configFile.writeText(originalConfig)
+      }
+      dir.deleteRecursively()
+    }
+  }
+
   private fun runCommand(
     runner: suspend (List<ResolvedJourney>) -> SuiteRunResult,
   ): RunCommand = RunCommand(suiteRunner = runner)
+
+  private fun dryRunCommand(
+    runner: suspend (List<ResolvedJourney>, File) -> DryRunSuiteReport,
+  ): RunCommand = RunCommand(dryRunSuiteRunner = runner)
 
   private fun writeJourney(
     dir: File,
@@ -210,6 +456,27 @@ class RunCommandTest {
       steps:
         - "[?] Home"
       """.trimIndent(),
+    )
+    return file
+  }
+
+  private fun writeJourneyWithSteps(
+    dir: File,
+    name: String,
+    journeyName: String,
+    platform: String = "android-tv",
+    steps: List<String>,
+  ): File {
+    val file = File(dir, name)
+    file.writeText(
+      buildString {
+        appendLine("name: $journeyName")
+        appendLine("app: com.example.app")
+        appendLine("platform: $platform")
+        appendLine()
+        appendLine("steps:")
+        steps.forEach { step -> appendLine("  - \"${step.replace("\\", "\\\\").replace("\"", "\\\"")}\"") }
+      },
     )
     return file
   }


### PR DESCRIPTION
## Summary
- Add `verity run --dry-run` with CLI planning, Markdown rendering, and per-journey artifacts under `<output-path>/dry-run`.
- Keep fast-path-only dry-runs device-free and provider-free, while lazily validating/generating slow-path Maestro YAML.
- Cover dry-run planner, artifact writer, CLI behavior, preflight, and architecture docs.

## Test Plan
- [x] `rtk gradlew check`